### PR TITLE
Use pre-shadow version of JM

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -37,7 +37,7 @@ dependencies {
     api("com.github.GTNewHorizons:GTNHLib:0.5.5:dev")
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.6.34-GTNH:dev")
 
-    compileOnlyApi(rfg.deobf('maven.modrinth:journeymap:5.2.5'))
+    compileOnlyApi(deobf("https://github.com/TeamJM/journeymap-legacy/releases/download/5.2.5/journeymap-1.7.10-5.2.5-unlimited-dev-preshadow.jar"))
     compileOnly(deobfCurse('xaeros-minimap-263420:5637000'))
     compileOnly(deobfCurse('xaeros-world-map-317780:5658209'))
     compileOnly(deobf('https://media.forgecdn.net/files/2462/146/mod_voxelMap_1.7.0b_for_1.7.10.litemod', 'mod_voxelMap_1.7.0b_for_1.7.10.jar'))


### PR DESCRIPTION
Journeymap shadows a bunch of really annoying things such as the jetbrains annotations and the intellij.lang annotations which overrides the usual ones in all dependents of Navigator so that they end up with imports such as `journeymap.shadow.org.jetbrains.annotations.NotNull`.

Not a single one of its many shadows are required for Navigator or its dependents at compile time.