### PR TITLE
Defeat

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -37,7 +37,7 @@ dependencies {
     api("com.github.GTNewHorizons:GTNHLib:0.5.5:dev")
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.6.34-GTNH:dev")
 
-    compileOnlyApi(deobf("https://github.com/TeamJM/journeymap-legacy/releases/download/5.2.5/journeymap-1.7.10-5.2.5-unlimited-dev-preshadow.jar"))
+    compileOnlyApi(rfg.deobf('maven.modrinth:journeymap:5.2.5'))
     compileOnly(deobfCurse('xaeros-minimap-263420:5637000'))
     compileOnly(deobfCurse('xaeros-world-map-317780:5658209'))
     compileOnly(deobf('https://media.forgecdn.net/files/2462/146/mod_voxelMap_1.7.0b_for_1.7.10.litemod', 'mod_voxelMap_1.7.0b_for_1.7.10.jar'))


### PR DESCRIPTION
The other dependency notation makes JM not get pulled in transitively and since JM isn't hosted on any maven there's no other way to get the preshadowed version. 
Dependents will just have to live with it ig