### PR TITLE
Readd removed methods

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -37,7 +37,7 @@ dependencies {
     api("com.github.GTNewHorizons:GTNHLib:0.5.5:dev")
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.6.34-GTNH:dev")
 
-    compileOnlyApi(rfg.deobf('maven.modrinth:journeymap:5.2.5'))
+    compileOnlyApi(rfg.deobf('maven.modrinth:journeymap:5.2.6'))
     compileOnly(deobfCurse('xaeros-minimap-263420:5637000'))
     compileOnly(deobfCurse('xaeros-world-map-317780:5658209'))
     compileOnly(deobf('https://media.forgecdn.net/files/2462/146/mod_voxelMap_1.7.0b_for_1.7.10.litemod', 'mod_voxelMap_1.7.0b_for_1.7.10.jar'))

--- a/src/main/java/com/gtnewhorizons/navigator/api/util/DrawUtils.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/util/DrawUtils.java
@@ -13,6 +13,7 @@ import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;
 
+@SuppressWarnings("unused")
 public class DrawUtils {
 
     public static void drawGradientRect(double minPixelX, double minPixelY, double maxPixelX, double maxPixelY,
@@ -55,37 +56,30 @@ public class DrawUtils {
 
     public static void drawQuad(ResourceLocation texture, double x, double y, double width, double height, int color,
         int alpha) {
-
         GL11.glEnable(GL11.GL_BLEND);
         OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 0);
-
         GL11.glEnable(GL11.GL_TEXTURE_2D);
         Minecraft.getMinecraft()
             .getTextureManager()
             .bindTexture(texture);
-
-        float[] c = floats(color);
-        GL11.glColor4f(c[0], c[1], c[2], alpha);
-
         Tessellator tessellator = Tessellator.instance;
         tessellator.startDrawingQuads();
         addRectToBufferWithUV(tessellator, x, y, width, height, color, alpha, 0, 0, 1, 1);
         tessellator.draw();
     }
 
-    public static void drawQuad(IIcon icon, double x, double y, double width, double height, int color, int alpha) {
+    public static void drawQuad(ResourceLocation texture, double x, double y, double width, double height, int color,
+        float alpha) {
+        drawQuad(texture, x, y, width, height, color, (int) alpha);
+    }
 
+    public static void drawQuad(IIcon icon, double x, double y, double width, double height, int color, int alpha) {
         GL11.glEnable(GL11.GL_BLEND);
         OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 0);
-
         GL11.glEnable(GL11.GL_TEXTURE_2D);
         Minecraft.getMinecraft()
             .getTextureManager()
             .bindTexture(TextureMap.locationBlocksTexture);
-
-        float[] c = floats(color);
-        GL11.glColor4f(c[0], c[1], c[2], alpha);
-
         Tessellator tessellator = Tessellator.instance;
         tessellator.startDrawingQuads();
         addRectToBufferWithUV(
@@ -101,6 +95,10 @@ public class DrawUtils {
             icon.getMaxU(),
             icon.getMaxV());
         tessellator.draw();
+    }
+
+    public static void drawQuad(IIcon icon, double x, double y, double width, double height, int color, float alpha) {
+        drawQuad(icon, x, y, width, height, color, (int) alpha);
     }
 
     public static void addRectToBuffer(Tessellator tessellator, double x, double y, double w, double h, int color,


### PR DESCRIPTION
I changed the alpha from float to int in https://github.com/GTNewHorizons/Navigator/pull/5 as it was already treated as such, but that accidentally broke the thaumcraft node layer since the method signature changed. Casting to int here is fine and the `glColor4f` is not necessary as the color is already being set in `addRectToBufferWithUV`.

This is also what's causing https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16169#issuecomment-2365154088

```
[14:04:47] [Client thread/ERROR] [journeymap]: Error during MiniMap.drawMap(): 'void com.gtnewhorizons.navigator.api.util.DrawUtils.drawQuad(net.minecraft.util.ResourceLocation, double, double, double, double, int, float)' (SUPPRESSED)
[14:04:47] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:787]: java.lang.NoSuchMethodError: 'void com.gtnewhorizons.navigator.api.util.DrawUtils.drawQuad(net.minecraft.util.ResourceLocation, double, double, double, double, int, float)'
[14:04:47] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:787]: 	at Launch//com.dyonovan.tcnodetracker.integration.navigator.journeymap.ThaumcraftNodeDrawStep.draw(ThaumcraftNodeDrawStep.java:59)
[14:04:47] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:787]: 	at Launch//journeymap.client.ui.minimap.MiniMap.handler$zgj000$navigator$onBeforeDrawWaypoints(MiniMap.java:773)
[14:04:47] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:787]: 	at Launch//journeymap.client.ui.minimap.MiniMap.drawOnMapWaypoints(MiniMap.java)
[14:04:47] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:787]: 	at Launch//journeymap.client.ui.minimap.MiniMap.drawMap(MiniMap.java:261)
[14:04:47] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:787]: 	at Launch//journeymap.client.ui.minimap.MiniMap.drawMap(MiniMap.java:129)
[14:04:47] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:787]: 	at Launch//journeymap.client.ui.UIManager.drawMiniMap(UIManager.java:152)
[14:04:47] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:787]: 	at Launch//journeymap.client.forge.event.MiniMapOverlayHandler.onRenderOverlay(MiniMapOverlayHandler.java:120)
[14:04:47] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:787]: 	at cpw.mods.fml.common.eventhandler.ASMEventHandler_110_MiniMapOverlayHandler_onRenderOverlay_RenderGameOverlayEvent.invoke(.dynamic)
[14:04:47] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:787]: 	at Launch//cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54)
[14:04:47] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:787]: 	at Launch//cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140)
[14:04:47] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:787]: 	at Launch//net.minecraftforge.client.GuiIngameForge.pre(GuiIngameForge.java:901)
[14:04:47] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:787]: 	at Launch//net.minecraftforge.client.GuiIngameForge.renderGameOverlay(GuiIngameForge.java:105)
[14:04:47] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:787]: 	at Launch//net.minecraft.client.renderer.EntityRenderer.updateCameraAndRender(EntityRenderer.java:1114)
[14:04:47] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:787]: 	at Launch//net.minecraft.client.Minecraft.runGameLoop(Minecraft.java:1067)
[14:04:47] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:787]: 	at Launch//net.minecraft.client.Minecraft.run(Minecraft.java:962)
[14:04:47] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:787]: 	at Launch//net.minecraft.client.main.Main.main(Main.java:164)
[14:04:47] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:787]: 	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
[14:04:47] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:787]: 	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
```

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17420