### PR TITLE
Fix JourneyMap RenderWaypointBeaconMixin injection failure

### DIFF
--- a/src/main/java/com/gtnewhorizons/navigator/mixins/late/journeymap/RenderWaypointBeaconMixin.java
+++ b/src/main/java/com/gtnewhorizons/navigator/mixins/late/journeymap/RenderWaypointBeaconMixin.java
@@ -33,8 +33,7 @@ public abstract class RenderWaypointBeaconMixin {
         method = "renderAll(F)V",
         at = @At(
             value = "INVOKE",
-            target = "Ljourneymap/client/waypoint/WaypointStore;instance()Ljourneymap/client/waypoint/WaypointStore;"
-        ),
+            target = "Ljourneymap/client/waypoint/WaypointStore;instance()Ljourneymap/client/waypoint/WaypointStore;"),
         remap = false,
         require = 1)
     private static void navigator$onRenderAll(float partialTicks, CallbackInfo ci) {
@@ -42,7 +41,8 @@ public abstract class RenderWaypointBeaconMixin {
             WaypointManager waypointManager = layer.getWaypointManager(JourneyMap);
             if (waypointManager instanceof JMWaypointManager jmWaypointManager && waypointManager.hasWaypoint()) {
                 final Waypoint waypoint = jmWaypointManager.getJmWaypoint();
-                if (waypoint.getDimensions().contains(mc.thePlayer.dimension)) {
+                if (waypoint.getDimensions()
+                    .contains(mc.thePlayer.dimension)) {
                     doRender(waypoint);
                 }
             }

--- a/src/main/java/com/gtnewhorizons/navigator/mixins/late/journeymap/RenderWaypointBeaconMixin.java
+++ b/src/main/java/com/gtnewhorizons/navigator/mixins/late/journeymap/RenderWaypointBeaconMixin.java
@@ -18,7 +18,7 @@ import com.gtnewhorizons.navigator.api.model.waypoints.WaypointManager;
 import journeymap.client.model.Waypoint;
 import journeymap.client.render.ingame.RenderWaypointBeacon;
 
-@Mixin(RenderWaypointBeacon.class)
+@Mixin(value = RenderWaypointBeacon.class, remap = false)
 public abstract class RenderWaypointBeaconMixin {
 
     @Shadow(remap = false)
@@ -30,19 +30,19 @@ public abstract class RenderWaypointBeaconMixin {
     }
 
     @Inject(
-        method = "renderAll",
+        method = "renderAll(F)V",
         at = @At(
             value = "INVOKE",
-            target = "Ljourneymap/client/waypoint/WaypointStore;instance()Ljourneymap/client/waypoint/WaypointStore;"),
+            target = "Ljourneymap/client/waypoint/WaypointStore;instance()Ljourneymap/client/waypoint/WaypointStore;"
+        ),
         remap = false,
         require = 1)
-    private static void navigator$onRenderAll(CallbackInfo ci) {
+    private static void navigator$onRenderAll(float partialTicks, CallbackInfo ci) {
         for (InteractableLayerManager layer : NavigatorApi.getInteractableLayers()) {
             WaypointManager waypointManager = layer.getWaypointManager(JourneyMap);
             if (waypointManager instanceof JMWaypointManager jmWaypointManager && waypointManager.hasWaypoint()) {
                 final Waypoint waypoint = jmWaypointManager.getJmWaypoint();
-                if (waypoint.getDimensions()
-                    .contains(mc.thePlayer.dimension)) {
+                if (waypoint.getDimensions().contains(mc.thePlayer.dimension)) {
                     doRender(waypoint);
                 }
             }


### PR DESCRIPTION
https://discord.com/channels/181078474394566657/939305179524792340/1495098580460110015
**Fixes a crash during Mixin application for JourneyMap integration.**

**Root cause:**
The `RenderWaypointBeacon` class in JourneyMap has two overloads for `renderAll`: 
- `renderAll()` 
- `renderAll(float partialTicks)`

The previous `@Inject` target only specified `method = "renderAll"`. However, the required injection point (`INVOKE WaypointStore.instance()`) only exists in the `renderAll(float)` method. This caused Mixin to fail the injection check (`Scanned 0 target(s)`).

**Changes:**
1. Explicitly defined the target method signature as `renderAll(F)V`.
2. Added `float partialTicks` to the callback method signature.
3. Explicitly set `remap = false` on the `@Mixin` annotation to prevent mapping issues with 3rd-party mod classes.