### PR TITLE
Fix search bar cursor blinking too fast

### DIFF
--- a/src/main/java/com/gtnewhorizons/navigator/mixins/late/journeymap/FullscreenMixin.java
+++ b/src/main/java/com/gtnewhorizons/navigator/mixins/late/journeymap/FullscreenMixin.java
@@ -200,8 +200,14 @@ public abstract class FullscreenMixin extends JmUI {
             if (layerManager.isLayerActive() && layerManager.hasSearchField()) {
                 navigator$searchBar.setVisible(true);
                 navigator$searchBar.drawTextBox();
-                navigator$searchBar.updateCursorCounter();
             }
+        }
+    }
+
+    @Inject(method = "updateScreen", at = @At("RETURN"))
+    private void navigator$updateSearchBarCursor(CallbackInfo ci) {
+        if (navigator$searchBar != null && navigator$searchBar.getVisible()) {
+            navigator$searchBar.updateCursorCounter();
         }
     }
 


### PR DESCRIPTION
`updateCursorCounter()` was called in drawScreen() on every frame instead of `updateScreen()` once per tick, so the cursor blinked 3x faster than normal. Moved the call to a separate updateScreen inject.