### PR TITLE
Fix missing Topo button on JourneyMap fullscreen map

### DIFF
--- a/src/main/java/com/gtnewhorizons/navigator/mixins/late/journeymap/FullscreenMixin.java
+++ b/src/main/java/com/gtnewhorizons/navigator/mixins/late/journeymap/FullscreenMixin.java
@@ -82,6 +82,9 @@ public abstract class FullscreenMixin extends JmUI {
     ThemeButton buttonDay;
 
     @Shadow(remap = false)
+    ThemeToggle buttonTopo;
+
+    @Shadow(remap = false)
     MapChat chat;
 
     @Shadow(remap = false)
@@ -175,6 +178,7 @@ public abstract class FullscreenMixin extends JmUI {
         }
 
         buttonList.add(buttonCaves);
+        buttonList.add(buttonTopo);
         buttonList.add(buttonNight);
         buttonList.add(buttonDay);
         mapTypeToolbar = new ThemeToolbar(theme, buttonList);


### PR DESCRIPTION
The mixin rebuilds JourneyMap's map type toolbar and only re-adds the caves, night, and day buttons, dropping the topo toggle that JourneyMap added after this mixin was written. Added the missing button back to the rebuilt list.