### PR TITLE
Add JourneyMap 6 support while retaining JourneyMap 5 and Xaero support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,142 +5,32 @@ Navigator is an api mod that allows for other mods to add integration for
 * [Xaeros World](https://www.curseforge.com/minecraft/mc-mods/xaeros-world-map) & [Minimap](https://www.curseforge.com/minecraft/mc-mods/xaeros-minimap)
 * [VoxelMap](https://www.curseforge.com/minecraft/mc-mods/voxelmap) (Limited support)
 
-## Dependencies
-* [GTNHLib](https://www.curseforge.com/minecraft/mc-mods/gtnhlib)
-
+Map mods remain optional at runtime. A consumer owns its data and domain actions; Navigator owns viewport caching,
+layer buttons, rendering dispatch, search dispatch, and map-specific integration.
 
 ## Documentation
-### Example Layer Implementation
-Navigator provides a debug layer which can also be used as a template for your own layers.
-* [JourneyMap Dirty Chunk Layer](https://github.com/GTNewHorizons/Navigator/tree/master/src/main/java/com/gtnewhorizons/navigator/impl/journeymap)
-* [Xaeros Dirty Chunk Layer ](https://github.com/GTNewHorizons/Navigator/tree/master/src/main/java/com/gtnewhorizons/navigator/impl/xaero)
-* [The ButtonManger, LayerManager and the ILocationProvider](https://github.com/GTNewHorizons/Navigator/tree/master/src/main/java/com/gtnewhorizons/navigator/impl) are always shared between the two mods.
 
-### Example JourneyMap Layer
+- [API guide](docs/API.md) - architecture, complete examples, caching, interaction, waypoints, JourneyMap 6 native
+  overlays, search, and compatibility guidance
+- [`NavigatorApi`](src/main/java/com/gtnewhorizons/navigator/api/NavigatorApi.java) - registration entry point
 
-Navigator provides an API for custom and interactive layers.
-This API will keep all maps as optional mod at runtime and not crash you game if it is missing.
+The preferred implementation path is map-neutral:
 
-Start by extending [`LayerManager`](https://github.com/GTNewHorizons/Navigator/blob/master/src/main/java/com/gtnewhorizons/navigator/api/model/layers/LayerManager.java) this will eventually handle all the logic behind your layer and will also generate a cached list of your [`ILocationProvider`](https://github.com/GTNewHorizons/Navigator/blob/master/src/main/java/com/gtnewhorizons/navigator/api/model/locations/ILocationProvider.java) implementation.
-You should only add whatever items are visible to this list. There are more methods to override, that will assist you with that. Take a look!
-
-```java
-class MyLayerManager extends LayerManager {
-
-    public static final MyLayerManager INSTANCE = new MyLayerManager();
-
-    public MyLayerManager() {
-        super(buttonManager);
-    }
-
-    @Nullable
-    @Override
-    protected LayerRenderer addLayerRenderer(InteractableLayerManager manager, SupportedMods mod) {
-      // You can safely return null here until you have implemented your own LayerRenderer.
-        if(mod == SupportedMods.JourneyMap) {
-          return new MyLayerRenderer();
-        }
-        return null;
-    }
-
-    @Override
-    public void updateElement(ILocationProvider location) {
-      // Update the information of your location here
-    }
-
-    @Override
-    protected @Nullable ILocationProvider generateLocation(int chunkX, int chunkZ, int dim) {
-        return new MyLocation();
-    }
-}
-```
-
-Next up extend [`ButtonManager`](https://github.com/GTNewHorizons/Navigator/blob/master/src/main/java/com/gtnewhorizons/navigator/api/model/buttons/ButtonManager.java) to create your own logical button.
-```java
-class MyButtonManager extends ButtonManager {
-
-  public static final MyButtonManager INSTANCE = new MyButtonManager();
-
-  @Override
-  public ResourceLocation getIcon(SupportedMods mod, String theme) {
-    return new ResourceLocation(YOUR_MOD_ID, "textures/icons/example.png");
-  }
-
-  @Override
-  public String getButtonText() {
-    return "My Button";
-  }
-}
-```
-If you start the game now, you will see a new button in the menu!
-
-Continue by implementing [`ILocationProvider`](https://github.com/GTNewHorizons/Navigator/blob/master/src/main/java/com/gtnewhorizons/navigator/api/model/locations/ILocationProvider.java). This class is a container and will provide all information required to display your item on screen. It won't do any rendering.
-
-```java
-class MyLocation implements ILocationProvider {
-
-    public int getDimensionId() {
-        return 0; // overworld
-    }
-
-    public int getBlockX() {
-        return 0;
-    }
-
-    public int getBlockY() {
-        return 65;
-    }
-
-    public int getBlockZ() {
-        return 0;
-    }
-
-    public String getLabel() {
-        return "Hello Minecraft";
-    }
-}
-```
-
-Congratulations, you have finished the logical implementation of your custom map layer! Now it is time for the visual integration. This example is provided for JourneyMap, but you might as well take a look at the other possibilities. You will need to follow it up with an implementation of `JMRenderStep`,  this class will receive an instance of `MyLocation` and perform the actual rendering.
-
-```java
-class MyDrawStep implements JMRenderStep {
-
-    private final MyLocation myLocation;
-
-    public MyDrawStep(MyLocation myLocation) {
-        this.myLocation = myLocation;
-    }
-
-    @Override
-    public void draw(double draggedPixelX, double draggedPixelY, GridRenderer gridRenderer, float drawScale, double fontScale, double rotation) {
-        final double blockSize = Math.pow(2, gridRenderer.getZoom());
-        final Point2D.Double blockAsPixel = gridRenderer.getBlockPixelInGrid(myLocation.getBlockX(), myLocation.getBlockZ());
-        final Point2D.Double pixel = new Point2D.Double(blockAsPixel.getX() + draggedPixelX, blockAsPixel.getY() + draggedPixelY);
-
-        DrawUtil.drawLabel(myLocation.getText(), pixel.getX(), pixel.getY(), DrawUtil.HAlign.Center, DrawUtil.VAlign.Middle, 0, 180, 0x00FFFFFF, 255, fontScale, false, rotation);
-    }
-}
-```
-
-Continue with your own implementation of [`JMLayerRenderer`](https://github.com/GTNewHorizons/Navigator/blob/master/src/main/java/com/gtnewhorizons/navigator/api/journeymap/render/JMLayerRenderer.java). This class will cache all `Renderstep`s and provide it to JourneyMap whenever it is time to render.
-
-```java
-class MyLayerRenderer extends JMLayerRenderer {
-
-    public MyLayerRenderer() {
-        super(MyLayerManager.instance);
-    }
-
-    @Override
-    protected @Nullable RenderStep generateRenderStep(ILocationProvider location) {
-        return new MyDrawStep((MyLocation) location);
-    }
-}
-```
-
-Finally, you will need to register your new layer with Navigator. This should only be done client-side and is done through the [`NavigatorAPI`](https://github.com/GTNewHorizons/Navigator/blob/master/src/main/java/com/gtnewhorizons/navigator/api/NavigatorApi.java) class during any one of the init phases.
+1. Implement `ILocationProvider` for the data shown on the map.
+2. Extend `ButtonManager` and `LayerManager` (or `InteractableLayerManager`).
+3. Extend `UniversalRenderStep` for rendering.
+4. Use `UniversalLocationInteractableStep` for non-waypoint interaction, or `UniversalInteractableStep` when
+   double-click should toggle a waypoint.
+5. Return a `UniversalLayerRenderer` / `UniversalInteractableRenderer` from the manager and register it client-side.
 
 ```java
 NavigatorApi.registerLayerManager(MyLayerManager.INSTANCE);
 ```
+
+Use the old JourneyMap- or Xaero-specific renderer APIs only when a universal render step cannot express the required
+behavior.
+
+## Dependency
+
+Navigator depends on [GTNHLib](https://github.com/GTNewHorizons/GTNHLib). Consumer mods should compile against
+Navigator while keeping supported map mods optional unless they deliberately use a map-specific API.

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ The preferred implementation path is map-neutral:
 NavigatorApi.registerLayerManager(MyLayerManager.INSTANCE);
 ```
 
-Use the old JourneyMap- or Xaero-specific renderer APIs only when a universal render step cannot express the required
-behavior.
+The JourneyMap-specific renderer and render-step APIs are deprecated because they support only JourneyMap 5. Use the
+universal APIs for JourneyMap 5, JourneyMap 6, and Xaero; map-specific APIs remain escape hatches only where the
+universal model cannot express required behavior.
 
 ## Dependency
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -316,6 +316,9 @@ Do not implement the waypoint interface merely to reuse double-click handling, a
 image or Minecraft `ResourceLocation`, source regions within sprite sheets or the animated block atlas, independent
 texture/display sizes, label styling, tooltip text, a label zoom threshold, and fullscreen-only labels.
 
+On JourneyMap 6, universal render steps draw only on the fullscreen map. A layer appears on the minimap only through a
+`MapMarker` or raw native overlay.
+
 ```java
 UniversalInteractableRenderer renderer = new UniversalInteractableRenderer(manager);
 renderer.withRenderStep(location -> new OreRenderStep((OreLocation) location));

--- a/docs/API.md
+++ b/docs/API.md
@@ -14,9 +14,9 @@ A layer has four parts:
 | `ILocationProvider` | Identifies one logical element and supplies its dimension and world position. |
 | `LayerRenderer` + `RenderStep` | Converts cached locations into visible map output. |
 
-Navigator calls the manager for every chunk covered by the largest active fullscreen/minimap viewport. The manager
-caches returned locations per dimension. Each renderer then caches one render step per location identity and receives
-only the currently visible set.
+Navigator either calls the manager for every chunk covered by the largest active fullscreen/minimap viewport or asks
+for one collection covering that viewport. The manager caches returned locations per dimension. Each renderer then
+caches one render step per location identity and receives only the currently visible set.
 
 Register each manager once, on the client, during an initialization phase:
 
@@ -61,9 +61,7 @@ public final class MyLocation implements ILocationProvider {
 ```
 
 The default identity, `toLong()`, is the packed chunk position. This is correct for chunk-grid data and for one point
-per chunk. Override it when a larger element uses another stable identity. Navigator's current manager cache still
-discovers at most one new location from each chunk lookup; arbitrary multiple points in one chunk need a consumer-owned
-aggregation or a future location-cache API.
+per chunk. Override it with a stable layer-unique key when using multiple points per chunk or another logical identity.
 
 Coordinates may be fractional. Negative coordinates are converted with floor-compatible chunk semantics.
 
@@ -140,12 +138,30 @@ public final class MyLayerManager extends LayerManager {
 `addLayerRenderer` is called once for each installed and enabled map integration. Return `null` for an integration the
 layer does not support. A universal renderer can be returned for every integration.
 
+For multiple independently interactive points in one chunk, override the collection hook instead of
+`generateLocation`:
+
+```java
+@Override
+protected Collection<? extends ILocationProvider> generateVisibleLocations(
+        int minBlockX, int minBlockZ, int maxBlockX, int maxBlockZ, int dimension) {
+    return MyDataStore.findAll(minBlockX, minBlockZ, maxBlockX, maxBlockZ, dimension);
+}
+```
+
+Return an empty collection when the viewport contains nothing. The default `null` return keeps chunk discovery active.
+Every returned location must override `toLong()` when more than one element may occupy a chunk. Navigator retains the
+first object for each identity; update mutable cached fields through `updateElement` or invalidate the location when
+its source data changes.
+
 ## Cache and refresh lifecycle
 
 ### Discovery
 
 - `generateLocation(chunkX, chunkZ, dimension)` is called when a chunk key is absent from the current dimension cache.
 - Returning `null` means there is no element for that chunk.
+- `generateVisibleLocations(...)` replaces chunk lookup for collection-backed layers and may return multiple stable
+  identities from one chunk. Returning `null` selects chunk lookup; an empty collection means no visible elements.
 - `getElementSize()` expands viewport discovery by that many chunks on every side. Override it for elements whose
   visual bounds extend beyond their identifying chunk.
 - `onUpdatePre` and `onUpdatePost` receive inclusive chunk bounds around a recache. They are appropriate for batched

--- a/docs/API.md
+++ b/docs/API.md
@@ -172,17 +172,18 @@ its source data changes.
 
 ### Invalidating data
 
-Call `forceRefresh()` after data changes outside `updateElement`. It schedules a redraw and increments the refresh
-version used by the JourneyMap 6 native-overlay synchronizer.
+Call `forceRefresh()` after data changes outside `updateElement`. It schedules a redraw and publishes one layer-change
+notification. JourneyMap 6 coalesces repeated notifications and recreates retained native overlays on the client
+thread; viewport changes are synchronized separately without recreating unchanged overlays.
 
 Use the narrowest cache operation that matches the change:
 
 | Operation | Effect |
 | --- | --- |
-| `removeLocation(...)` | Queues one location and its render step for removal. |
+| `removeLocation(...)` | Invalidates one location and its render step, optionally in an explicit dimension. |
 | `clearCurrentCache()` | Clears the current dimension on the next recache. |
 | `clearFullCache()` | Clears every dimension and every renderer cache. |
-| `addExtraLocation(location)` | Inserts an already-created location into the current dimension cache. |
+| `addExtraLocation(location)` | Inserts an already-created location and schedules synchronization. |
 
 `getVisibleLocations()` is the current viewport set. `getCachedLocations()` includes locations outside the viewport in
 the current dimension. Treat both collections as manager-owned; mutating them directly couples code to cache internals.
@@ -209,9 +210,10 @@ public void onSearch(@NotNull String searchString) {
 }
 ```
 
-Search policy belongs to the consumer because Navigator does not know which fields are meaningful. The JourneyMap 6
-search widget currently has a known focus conflict when switching directly to Minecraft chat; see the compatibility
-roadmap.
+Search policy belongs to the consumer because Navigator does not know which fields are meaningful. Navigator sends
+query changes to inactive searchable layers too, so switching layers preserves and immediately applies the current
+filter. The JourneyMap 6 search widget currently has a known focus conflict when switching directly to Minecraft chat;
+see the compatibility roadmap.
 
 ## Interaction without waypoints
 
@@ -374,9 +376,9 @@ If the consumer supplies a listener, Navigator leaves it untouched. Set `replace
 overlays fully replace the universal step on the JourneyMap 6 fullscreen map. Minimap rendering is native-overlay only;
 JourneyMap 5 and Xaero continue using the universal render step.
 
-Native overlays are retained while their location remains visible. `forceRefresh()` recreates overlays for visible
-locations and removes overlays that left the refreshed visible set. Avoid calling it every tick unless domain data
-actually changed.
+Native overlays are retained while their location remains visible. JourneyMap display updates add and remove overlays
+as the viewport changes; `forceRefresh()` recreates overlays for visible locations after domain data changes. Avoid
+calling it every tick unless domain data actually changed.
 
 Because this path uses JourneyMap 6 classes in consumer code, isolate the factory behind a JM6 runtime check and keep
 those classes out of code that must load under JourneyMap 5.

--- a/docs/API.md
+++ b/docs/API.md
@@ -108,7 +108,8 @@ public final class MyRenderStep extends UniversalRenderStep<MyLocation> {
 
 `x` and `y` are map-space coordinates for the location. Use `getAdjustedWidth()` / `getAdjustedHeight()` when the
 size should remain consistent across integrations. `getZoomStep()` provides Navigator's normalized, discrete zoom
-step for visibility decisions.
+step for visibility decisions. `getZoomScale(...)` returns a clamped linear multiplier over a consumer-selected zoom
+range, allowing each layer to tune label or icon sizing without map-specific zoom calculations.
 
 ### Manager and renderer
 
@@ -314,7 +315,8 @@ Do not implement the waypoint interface merely to reuse double-click handling, a
 
 `MapMarker` is Navigator's map-neutral description of a native JourneyMap 6 `MarkerOverlay`. It supports a buffered
 image or Minecraft `ResourceLocation`, source regions within sprite sheets or the animated block atlas, independent
-texture/display sizes, label styling, tooltip text, a label zoom threshold, and fullscreen-only labels.
+texture/display sizes, label styling, tooltip text, a label zoom threshold, fullscreen-only labels, and independent
+fullscreen zoom scaling for its icon and label.
 
 On JourneyMap 6, universal render steps draw only on the fullscreen map. A layer appears on the minimap only through a
 `MapMarker` or raw native overlay.
@@ -324,7 +326,9 @@ UniversalInteractableRenderer renderer = new UniversalInteractableRenderer(manag
 renderer.withRenderStep(location -> new OreRenderStep((OreLocation) location));
 renderer.withMapMarker(location -> new MapMarker(ORE_ICON, 16, 16)
     .setDisplaySize(12, 12)
+    .setDisplayZoomScale(1, 2, 3, 5)
     .setLabel(((OreLocation) location).getName())
+    .setLabelZoomScale(1, 1.5, 0, 5)
     .setLabelMinZoom(3)
     .setLabelOnMinimap(false));
 return renderer;
@@ -339,6 +343,7 @@ Important lifecycle rules:
 - Marker clicks and action keys are forwarded to `UniversalInteractableRenderer`.
 - `setLabelMinZoom` uses Navigator's normalized zoom steps, not JourneyMap's internal zoom value.
 - `setLabelOnMinimap(false)` hides only the text; the icon remains visible in both contexts.
+- `setDisplayZoomScale` and `setLabelZoomScale` affect only fullscreen; the minimap retains the configured base size.
 - Use `new MapMarker(TextureMap.locationBlocksTexture, sprite)` to reuse a stitched `TextureAtlasSprite` directly
   without copying it or losing its animation.
 
@@ -390,6 +395,7 @@ those classes out of code that must load under JourneyMap 5.
 | `setMinScale(...)` | Xaero-only lower scaling bound. |
 | `isMinimap()` | Whether no GUI screen is currently open. |
 | `getZoomStep()` | Normalized zoom step suitable for visibility thresholds. |
+| `getZoomScale(...)` | Scale interpolated over a consumer-selected normalized zoom range. |
 
 Rendering runs inside a pushed OpenGL matrix with Navigator's basic blend state configured. A render step must still
 restore any additional GL state it changes.

--- a/docs/API.md
+++ b/docs/API.md
@@ -313,8 +313,8 @@ Do not implement the waypoint interface merely to reuse double-click handling, a
 ## JourneyMap 6 point markers
 
 `MapMarker` is Navigator's map-neutral description of a native JourneyMap 6 `MarkerOverlay`. It supports a buffered
-image or Minecraft `ResourceLocation`, independent texture/display sizes, label styling, tooltip text, a label zoom
-threshold, and fullscreen-only labels.
+image or Minecraft `ResourceLocation`, source regions within sprite sheets or the animated block atlas, independent
+texture/display sizes, label styling, tooltip text, a label zoom threshold, and fullscreen-only labels.
 
 ```java
 UniversalInteractableRenderer renderer = new UniversalInteractableRenderer(manager);
@@ -336,6 +336,8 @@ Important lifecycle rules:
 - Marker clicks and action keys are forwarded to `UniversalInteractableRenderer`.
 - `setLabelMinZoom` uses Navigator's normalized zoom steps, not JourneyMap's internal zoom value.
 - `setLabelOnMinimap(false)` hides only the text; the icon remains visible in both contexts.
+- Use `new MapMarker(TextureMap.locationBlocksTexture, sprite)` to reuse a stitched `TextureAtlasSprite` directly
+  without copying it or losing its animation.
 
 On JourneyMap 5 and Xaero, the universal render step remains the visual implementation. `MapMarker` itself is ignored.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -215,8 +215,7 @@ public void onSearch(@NotNull String searchString) {
 
 Search policy belongs to the consumer because Navigator does not know which fields are meaningful. Navigator sends
 query changes to inactive searchable layers too, so switching layers preserves and immediately applies the current
-filter. The JourneyMap 6 search widget currently has a known focus conflict when switching directly to Minecraft chat;
-see the compatibility roadmap.
+filter. Navigator also releases map-search focus when JourneyMap 6 opens Minecraft chat.
 
 ## Interaction without waypoints
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -402,8 +402,9 @@ custom renderer.
 The preferred path is universal. The following APIs remain for compatibility or behavior that cannot be expressed by
 a universal step:
 
-- `JMRenderStep`, `JMInteractableStep`, `JMLayerRenderer`, and `JMInteractableLayerRenderer` target the JourneyMap 5
-  draw-step API. They directly reference JourneyMap client classes.
+- `JMRenderStep`, `JMInteractableStep`, `JMLayerRenderer`, and `JMInteractableLayerRenderer` are deprecated JourneyMap
+  5-only APIs. New and migrated layers should use their universal equivalents so the same implementation also works
+  with JourneyMap 6 and Xaero.
 - `XaeroRenderStep`, `XaeroInteractableStep`, `XaeroLayerRenderer`, and `XaeroInteractableLayerRenderer` target Xaero's
   renderer API directly.
 - `JMWaypointManager` selects the JourneyMap 5 implementation or delegates to JourneyMap 6 internally.

--- a/docs/API.md
+++ b/docs/API.md
@@ -424,6 +424,19 @@ a universal step:
 Do not load a map-specific implementation when its map mod is absent. Select it in `addLayerRenderer` or
 `addWaypointManager` using the supplied `SupportedMods` value.
 
+### Migrating existing JourneyMap consumers
+
+`SupportedMods.JourneyMap` now represents either JourneyMap 5 or JourneyMap 6. Existing consumers that return
+`JMLayerRenderer` or `JMInteractableLayerRenderer` must do so only when `Util.isJourneyMapV5Installed()` is true;
+those legacy classes cannot load under JourneyMap 6. Prefer a universal renderer for both versions.
+
+Universal render steps no longer implement JourneyMap 5's `JMRenderStep`/`DrawStep` types. Code should render and
+interact through the universal APIs instead of casting a universal step to a JourneyMap class.
+
+`InteractableLayerManager#getVisibleLocations()` may now contain plain `ILocationProvider` elements because
+interaction no longer implies waypoint capability. Consumers that need waypoint locations should filter with
+`instanceof IWaypointAndLocationProvider`.
+
 ## JourneyMap version detection
 
 Use `JourneyMapVersion.get()` or the convenience methods in `Util`:

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,423 @@
+# Navigator API guide
+
+This guide documents Navigator's supported extension points. It focuses on the universal API, which keeps a consumer
+independent of the installed map mod, and then covers the map-specific escape hatches.
+
+## Mental model
+
+A layer has four parts:
+
+| Part | Responsibility |
+| --- | --- |
+| `ButtonManager` | One shared toggle and its map-specific icon. |
+| `LayerManager` | Finds, caches, updates, filters, and removes logical locations. |
+| `ILocationProvider` | Identifies one logical element and supplies its dimension and world position. |
+| `LayerRenderer` + `RenderStep` | Converts cached locations into visible map output. |
+
+Navigator calls the manager for every chunk covered by the largest active fullscreen/minimap viewport. The manager
+caches returned locations per dimension. Each renderer then caches one render step per location identity and receives
+only the currently visible set.
+
+Register each manager once, on the client, during an initialization phase:
+
+```java
+NavigatorApi.registerLayerManager(MyLayerManager.INSTANCE);
+```
+
+## Minimal universal layer
+
+### Location
+
+`ILocationProvider` is intentionally small:
+
+```java
+public final class MyLocation implements ILocationProvider {
+
+    private final int dimension;
+    private final int blockX;
+    private final int blockZ;
+
+    public MyLocation(int dimension, int blockX, int blockZ) {
+        this.dimension = dimension;
+        this.blockX = blockX;
+        this.blockZ = blockZ;
+    }
+
+    @Override
+    public int getDimensionId() {
+        return dimension;
+    }
+
+    @Override
+    public double getBlockX() {
+        return blockX;
+    }
+
+    @Override
+    public double getBlockZ() {
+        return blockZ;
+    }
+}
+```
+
+The default identity, `toLong()`, is the packed chunk position. This is correct for chunk-grid data and for one point
+per chunk. Override it when a larger element uses another stable identity. Navigator's current manager cache still
+discovers at most one new location from each chunk lookup; arbitrary multiple points in one chunk need a consumer-owned
+aggregation or a future location-cache API.
+
+Coordinates may be fractional. Negative coordinates are converted with floor-compatible chunk semantics.
+
+### Button
+
+```java
+public final class MyButtonManager extends ButtonManager {
+
+    public static final MyButtonManager INSTANCE = new MyButtonManager();
+
+    private MyButtonManager() {}
+
+    @Override
+    public ResourceLocation getIcon(SupportedMods mod, String theme) {
+        return new ResourceLocation("mymod", "textures/gui/map_layer.png");
+    }
+
+    @Override
+    public String getButtonText() {
+        return "Show my layer";
+    }
+}
+```
+
+Activating a Navigator button deactivates other distinct Navigator buttons. `setOnToggle` is for consumer-side work;
+the manager installs its own notification callback automatically.
+
+### Render step
+
+```java
+public final class MyRenderStep extends UniversalRenderStep<MyLocation> {
+
+    public MyRenderStep(MyLocation location) {
+        super(location);
+        setSize(16); // world blocks
+    }
+
+    @Override
+    public void draw(double x, double y, float drawScale, double zoom) {
+        DrawUtils.drawHollowRect(x, y, getAdjustedWidth(), getAdjustedHeight(), 0x00FF00, 180);
+    }
+}
+```
+
+`x` and `y` are map-space coordinates for the location. Use `getAdjustedWidth()` / `getAdjustedHeight()` when the
+size should remain consistent across integrations. `getZoomStep()` provides Navigator's normalized, discrete zoom
+step for visibility decisions.
+
+### Manager and renderer
+
+```java
+public final class MyLayerManager extends LayerManager {
+
+    public static final MyLayerManager INSTANCE = new MyLayerManager();
+
+    private MyLayerManager() {
+        super(MyButtonManager.INSTANCE);
+    }
+
+    @Override
+    protected LayerRenderer addLayerRenderer(LayerManager manager, SupportedMods mod) {
+        return new UniversalLayerRenderer(manager)
+            .withRenderStep(location -> new MyRenderStep((MyLocation) location));
+    }
+
+    @Override
+    protected ILocationProvider generateLocation(int chunkX, int chunkZ, int dimension) {
+        MyData data = MyDataStore.find(chunkX, chunkZ, dimension);
+        return data == null ? null : new MyLocation(dimension, data.blockX, data.blockZ);
+    }
+}
+```
+
+`addLayerRenderer` is called once for each installed and enabled map integration. Return `null` for an integration the
+layer does not support. A universal renderer can be returned for every integration.
+
+## Cache and refresh lifecycle
+
+### Discovery
+
+- `generateLocation(chunkX, chunkZ, dimension)` is called when a chunk key is absent from the current dimension cache.
+- Returning `null` means there is no element for that chunk.
+- `getElementSize()` expands viewport discovery by that many chunks on every side. Override it for elements whose
+  visual bounds extend beyond their identifying chunk.
+- `onUpdatePre` and `onUpdatePost` receive inclusive chunk bounds around a recache. They are appropriate for batched
+  network requests and validation.
+- `updateElement(location)` runs for every cached visible location during recache. Mutate the existing object there;
+  do not replace it merely to update fields.
+
+### Invalidating data
+
+Call `forceRefresh()` after data changes outside `updateElement`. It schedules a redraw and increments the refresh
+version used by the JourneyMap 6 native-overlay synchronizer.
+
+Use the narrowest cache operation that matches the change:
+
+| Operation | Effect |
+| --- | --- |
+| `removeLocation(...)` | Queues one location and its render step for removal. |
+| `clearCurrentCache()` | Clears the current dimension on the next recache. |
+| `clearFullCache()` | Clears every dimension and every renderer cache. |
+| `addExtraLocation(location)` | Inserts an already-created location into the current dimension cache. |
+
+`getVisibleLocations()` is the current viewport set. `getCachedLocations()` includes locations outside the viewport in
+the current dimension. Treat both collections as manager-owned; mutating them directly couples code to cache internals.
+
+When a layer is disabled, the default `onLayerToggled(false)` clears all caches. Override it only when consumer state
+also needs cleanup, and call `super`.
+
+## Search
+
+Enable Navigator's map search field in the manager constructor and respond to normalized text changes:
+
+```java
+private MyLayerManager() {
+    super(MyButtonManager.INSTANCE);
+    setHasSearchField(true);
+}
+
+@Override
+public void onSearch(@NotNull String searchString) {
+    for (MyLocation location : locations) {
+        location.setVisible(searchString.isEmpty() || location.getName().toLowerCase().contains(searchString));
+    }
+    forceRefresh();
+}
+```
+
+Search policy belongs to the consumer because Navigator does not know which fields are meaningful. The JourneyMap 6
+search widget currently has a known focus conflict when switching directly to Minecraft chat; see the compatibility
+roadmap.
+
+## Interaction without waypoints
+
+Interaction and waypoint capability are separate. A clickable element that is not a waypoint implements only
+`ILocationProvider`, and its step extends `UniversalLocationInteractableStep`:
+
+```java
+public final class ClaimRenderStep extends UniversalLocationInteractableStep<ClaimLocation> {
+
+    public ClaimRenderStep(ClaimLocation location) {
+        super(location);
+    }
+
+    @Override
+    public void draw(double x, double y, float drawScale, double zoom) {
+        DrawUtils.drawRect(x, y, getAdjustedWidth(), getAdjustedHeight(), location.getColor(), 135);
+    }
+
+    @Override
+    public void getTooltip(List<String> tooltip) {
+        tooltip.add(location.getOwnerName());
+    }
+
+    @Override
+    public void onActionKeyPressed() {
+        location.unclaim();
+    }
+}
+```
+
+Configure it with `UniversalInteractableRenderer`:
+
+```java
+UniversalInteractableRenderer renderer = new UniversalInteractableRenderer(manager)
+    .withClickAction(click -> {
+        if (!click.isDoubleClick()) return false;
+
+        LocationInteractableStep step = click.getLocationRenderStep();
+        if (step != null && step.getLocation() instanceof ClaimLocation claim) {
+            claim.toggleLoaded();
+            return true;
+        }
+
+        claimChunk(click.getChunkX(), click.getChunkZ());
+        return true;
+    });
+renderer.withRenderStep(location -> new ClaimRenderStep((ClaimLocation) location));
+return renderer;
+```
+
+Return `true` only when the callback consumed the event. Consumed clicks and action keys trigger a manager refresh.
+`ClickPos#getLocationRenderStep()` is the location-neutral accessor. `getRenderStep()` is retained for binary and
+source compatibility with older waypoint-only consumers and returns `null` for a plain-location step.
+
+Override `isMouseOver` when the default rectangular bounds do not match the shape. The bounds are derived from the
+step's current map-space position, size, and offset.
+
+## Waypoint-capable interaction
+
+Use `IWaypointAndLocationProvider` only when the element should participate in Navigator's active waypoint:
+
+```java
+public final class OreLocation implements IWaypointAndLocationProvider {
+
+    private boolean active;
+
+    @Override
+    public Waypoint toWaypoint() {
+        return new Waypoint(blockX, blockY, blockZ, dimension, name, color);
+    }
+
+    @Override
+    public boolean isActiveAsWaypoint() {
+        return active;
+    }
+
+    @Override
+    public void onWaypointUpdated(Waypoint waypoint) {
+        active = waypoint.blockX == blockX && waypoint.blockZ == blockZ && waypoint.dimensionId == dimension;
+    }
+
+    @Override
+    public void onWaypointCleared() {
+        active = false;
+    }
+}
+```
+
+Its render step extends `UniversalInteractableStep<OreLocation>`. `UniversalInteractableRenderer` then supplies the
+default behavior: double-clicking the hovered step sets or clears the active waypoint. A custom click callback runs
+first and may consume the click instead.
+
+An `InteractableLayerManager` may return map-specific `WaypointManager` instances from `addWaypointManager`. It only
+sends waypoint callbacks to visible locations that actually implement `IWaypointAndLocationProvider`; plain clickable
+locations are ignored safely.
+
+Do not implement the waypoint interface merely to reuse double-click handling, and never return `null` from
+`toWaypoint()` as a substitute for a domain action. Use the location-neutral interaction path above.
+
+## JourneyMap 6 point markers
+
+`MapMarker` is Navigator's map-neutral description of a native JourneyMap 6 `MarkerOverlay`. It supports a buffered
+image or Minecraft `ResourceLocation`, independent texture/display sizes, label styling, tooltip text, a label zoom
+threshold, and fullscreen-only labels.
+
+```java
+UniversalInteractableRenderer renderer = new UniversalInteractableRenderer(manager);
+renderer.withRenderStep(location -> new OreRenderStep((OreLocation) location));
+renderer.withMapMarker(location -> new MapMarker(ORE_ICON, 16, 16)
+    .setDisplaySize(12, 12)
+    .setLabel(((OreLocation) location).getName())
+    .setLabelMinZoom(3)
+    .setLabelOnMinimap(false));
+return renderer;
+```
+
+Important lifecycle rules:
+
+- `withRenderStep(...)` is still required. Visible render steps are the source of marker locations and interaction.
+- Navigator creates the `MapImage`, centers its anchors, assigns the location dimension, enables fullscreen and
+  minimap contexts, and owns show/remove/refresh lifecycle.
+- If `MapMarker#setTooltip` is not called, Navigator obtains tooltip lines from an interactable render step.
+- Marker clicks and action keys are forwarded to `UniversalInteractableRenderer`.
+- `setLabelMinZoom` uses Navigator's normalized zoom steps, not JourneyMap's internal zoom value.
+- `setLabelOnMinimap(false)` hides only the text; the icon remains visible in both contexts.
+
+On JourneyMap 5 and Xaero, the universal render step remains the visual implementation. `MapMarker` itself is ignored.
+
+## Raw JourneyMap 6 overlays
+
+Use `withJourneyMapV6Overlays` for native areas or images that `MapMarker` cannot describe:
+
+```java
+if (Util.isJourneyMapV6Installed()) {
+    renderer.withJourneyMapV6Overlays(location -> createClaimPolygons((ClaimLocation) location), true);
+}
+```
+
+The factory returns JourneyMap 6 `Displayable` objects as `Collection<?>`, keeping JM6 types out of Navigator's common
+API signature. The consumer remains responsible for each displayable's geometry, dimension, active UI contexts,
+display order, image properties, and stable identifiers.
+
+Navigator owns display lifecycle and refresh. For JourneyMap `Overlay` instances, Navigator also installs its
+interaction listener when all of the following are true:
+
+- the renderer is a `UniversalInteractableRenderer`;
+- the render step is a `UniversalLocationInteractableStep`;
+- the overlay does not already have a listener.
+
+If the consumer supplies a listener, Navigator leaves it untouched. Set `replaceRenderSteps` to `true` when native
+overlays fully replace the universal step on the JourneyMap 6 fullscreen map. Minimap rendering is native-overlay only;
+JourneyMap 5 and Xaero continue using the universal render step.
+
+Native overlays are retained while their location remains visible. `forceRefresh()` recreates overlays for visible
+locations and removes overlays that left the refreshed visible set. Avoid calling it every tick unless domain data
+actually changed.
+
+Because this path uses JourneyMap 6 classes in consumer code, isolate the factory behind a JM6 runtime check and keep
+those classes out of code that must load under JourneyMap 5.
+
+## Rendering details
+
+`UniversalRenderStep` exposes:
+
+| Method | Meaning |
+| --- | --- |
+| `preRender(...)` | Update size, offset, scale, or other derived state before each draw. |
+| `setSize(...)` | Logical width/height in world blocks. Defaults to one chunk. |
+| `setOffset(...)` | Map-space offset added to the calculated position. |
+| `getAdjustedWidth/Height()` | Size converted for the active integration. |
+| `getFontScale()` | Map-provided label scale. |
+| `setMinScale(...)` | Xaero-only lower scaling bound. |
+| `isMinimap()` | Whether no GUI screen is currently open. |
+| `getZoomStep()` | Normalized zoom step suitable for visibility thresholds. |
+
+Rendering runs inside a pushed OpenGL matrix with Navigator's basic blend state configured. A render step must still
+restore any additional GL state it changes.
+
+Render priorities are ascending. Use `withRenderPriority` on a universal renderer or override `getRenderPriority` on a
+custom renderer.
+
+## Map-specific APIs
+
+The preferred path is universal. The following APIs remain for compatibility or behavior that cannot be expressed by
+a universal step:
+
+- `JMRenderStep`, `JMInteractableStep`, `JMLayerRenderer`, and `JMInteractableLayerRenderer` target the JourneyMap 5
+  draw-step API. They directly reference JourneyMap client classes.
+- `XaeroRenderStep`, `XaeroInteractableStep`, `XaeroLayerRenderer`, and `XaeroInteractableLayerRenderer` target Xaero's
+  renderer API directly.
+- `JMWaypointManager` selects the JourneyMap 5 implementation or delegates to JourneyMap 6 internally.
+- `XaeroWaypointManager` publishes a Navigator-owned custom waypoint and disables it outside its dimension.
+- `VoxelMapWaypointManager` only provides waypoint creation helpers; VoxelMap has no Navigator layer renderer.
+
+Do not load a map-specific implementation when its map mod is absent. Select it in `addLayerRenderer` or
+`addWaypointManager` using the supplied `SupportedMods` value.
+
+## JourneyMap version detection
+
+Use `JourneyMapVersion.get()` or the convenience methods in `Util`:
+
+```java
+if (Util.isJourneyMapV6Installed()) {
+    // Configure JM6-native overlays.
+}
+```
+
+Detection is cached for the process lifetime. JM6 is identified by the public v2 client API class. Avoid parsing the
+mod version string.
+
+## Compatibility checklist
+
+Before shipping a consumer change, test:
+
+- JourneyMap 5 fullscreen rendering and interaction;
+- JourneyMap 6 fullscreen and minimap contexts;
+- Xaero World Map and Minimap rendering;
+- layer toggle off/on and returning to the menu;
+- dimension changes and negative coordinates;
+- tooltip enter/leave behavior and empty-space clicks;
+- search refresh, if enabled;
+- action key and double-click behavior;
+- compatibility with existing consumer jars when changing public fields or method descriptors.
+
+Navigator intentionally retains some legacy API shapes because 1.7.10 integrations and third-party mixins may access
+them by exact JVM descriptor. Prefer additive APIs over changing existing public/protected types.

--- a/docs/API.md
+++ b/docs/API.md
@@ -180,10 +180,13 @@ Use the narrowest cache operation that matches the change:
 
 | Operation | Effect |
 | --- | --- |
-| `removeLocation(...)` | Invalidates one location and its render step, optionally in an explicit dimension. |
+| `invalidateLocation(...)` | Invalidates one cached location and its render step, optionally in an explicit dimension. |
 | `clearCurrentCache()` | Clears the current dimension on the next recache. |
 | `clearFullCache()` | Clears every dimension and every renderer cache. |
 | `addExtraLocation(location)` | Inserts an already-created location and schedules synchronization. |
+
+The older `removeLocation(...)` name remains as a deprecated compatibility alias. Neither method deletes data owned by
+the consumer; invalidation makes Navigator recreate the location from that source during the next recache.
 
 `getVisibleLocations()` is the current viewport set. `getCachedLocations()` includes locations outside the viewport in
 the current dimension. Treat both collections as manager-owned; mutating them directly couples code to cache internals.

--- a/docs/API.md
+++ b/docs/API.md
@@ -139,8 +139,8 @@ public final class MyLayerManager extends LayerManager {
 `addLayerRenderer` is called once for each installed and enabled map integration. Return `null` for an integration the
 layer does not support. A universal renderer can be returned for every integration.
 
-For multiple independently interactive points in one chunk, override the collection hook instead of
-`generateLocation`:
+For a layer backed by an existing collection or map of known locations, override the collection hook instead of
+`generateLocation`. This also supports multiple independently interactive points in one chunk:
 
 ```java
 @Override
@@ -153,7 +153,9 @@ protected Collection<? extends ILocationProvider> generateVisibleLocations(
 Return an empty collection when the viewport contains nothing. The default `null` return keeps chunk discovery active.
 Every returned location must override `toLong()` when more than one element may occupy a chunk. Navigator retains the
 first object for each identity; update mutable cached fields through `updateElement` or invalidate the location when
-its source data changes.
+its source data changes. Do not probe a finite location collection from `generateLocation`: chunk discovery scales with
+viewport area, and highly zoomed-out maps can cover millions of chunks. Filter the collection by the supplied block
+bounds instead. Navigator expands those bounds by `getElementSize()` for elements extending beyond their origin.
 
 ## Cache and refresh lifecycle
 

--- a/src/main/java/com/gtnewhorizons/navigator/api/NavigatorApi.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/NavigatorApi.java
@@ -17,10 +17,7 @@ import com.gtnewhorizons.navigator.api.model.buttons.ButtonManager;
 import com.gtnewhorizons.navigator.api.model.layers.InteractableLayerManager;
 import com.gtnewhorizons.navigator.api.model.layers.LayerManager;
 import com.gtnewhorizons.navigator.api.model.layers.LayerRenderer;
-import com.gtnewhorizons.navigator.api.util.Util;
-import com.gtnewhorizons.navigator.mixins.late.journeymap.FullscreenAccessor;
-
-import journeymap.client.render.map.GridRenderer;
+import com.gtnewhorizons.navigator.internal.journeymap.JourneyMapIntegration;
 
 public final class NavigatorApi {
 
@@ -86,13 +83,8 @@ public final class NavigatorApi {
     }
 
     public void openJourneyMapAt(@Nullable LayerManager layer, int blockX, int blockZ, int zoom) {
-        if (!Util.isJourneyMapV5Installed()) return;
-        final GridRenderer gridRenderer = FullscreenAccessor.getGridRenderer();
-        if (gridRenderer == null) return;
-
         if (layer != null) layer.activateLayer();
-        if (zoom == -1) zoom = gridRenderer.getZoom();
-        gridRenderer.center(gridRenderer.getMapType(), blockX, blockZ, zoom);
+        JourneyMapIntegration.centerOn(blockX, blockZ, zoom);
     }
 
     public void openJourneyMapAt(@Nullable LayerManager layer, int blockX, int blockZ) {

--- a/src/main/java/com/gtnewhorizons/navigator/api/NavigatorApi.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/NavigatorApi.java
@@ -58,6 +58,7 @@ public final class NavigatorApi {
      */
     public static List<LayerRenderer> getActiveRenderersFor(SupportedMods mod) {
         return layerManagers.stream()
+            .filter(layerManager -> layerManager.isEnabled(mod))
             .filter(LayerManager::isLayerActive)
             .map(layerManager -> layerManager.getLayerRenderer(mod))
             .collect(Collectors.toList());

--- a/src/main/java/com/gtnewhorizons/navigator/api/NavigatorApi.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/NavigatorApi.java
@@ -19,23 +19,43 @@ import com.gtnewhorizons.navigator.api.model.layers.LayerManager;
 import com.gtnewhorizons.navigator.api.model.layers.LayerRenderer;
 import com.gtnewhorizons.navigator.internal.journeymap.JourneyMapIntegration;
 
+/**
+ * Client-side entry point for registering layers and querying the integrations Navigator currently exposes.
+ * <p>
+ * Register each {@link LayerManager} once during client initialization. Map mods are optional; a manager is only given
+ * renderers for integrations that are both installed and enabled in Navigator's configuration.
+ */
 public final class NavigatorApi {
 
+    /** Width of a Minecraft chunk in blocks. */
     public static final double CHUNK_WIDTH = 16;
+
+    /** Shared action key used by interactable render steps. Defaults to {@code DELETE}. */
     public static final KeyBinding ACTION_KEY = new KeyBinding(
         "navigator.key.action",
         Keyboard.KEY_DELETE,
         Navigator.MODNAME);
 
+    /** Registered layer managers. Consumers should use {@link #registerLayerManager(LayerManager)}. */
     public static final List<LayerManager> layerManagers = new ArrayList<>();
 
     /**
+     * Registers a layer manager with every applicable map integration.
+     * <p>
+     * This method does not deduplicate registrations.
+     *
      * @param layerManager The {@link LayerManager} to register.
      */
     public static void registerLayerManager(LayerManager layerManager) {
         layerManagers.add(layerManager);
     }
 
+    /**
+     * Returns active renderers for a map integration in registration order.
+     *
+     * @param mod map integration requesting renderers
+     * @return a new list of renderers belonging to active layers
+     */
     public static List<LayerRenderer> getActiveRenderersFor(SupportedMods mod) {
         return layerManagers.stream()
             .filter(LayerManager::isLayerActive)
@@ -43,18 +63,32 @@ public final class NavigatorApi {
             .collect(Collectors.toList());
     }
 
+    /**
+     * Returns active renderers sorted by ascending {@link LayerRenderer#getRenderPriority()}.
+     *
+     * @param mod map integration requesting renderers
+     * @return a new sorted list
+     */
     public static List<LayerRenderer> getActiveRenderersByPriority(SupportedMods mod) {
         List<LayerRenderer> list = getActiveRenderersFor(mod);
         list.sort(Comparator.comparingInt(LayerRenderer::getRenderPriority));
         return list;
     }
 
+    /**
+     * @param mod map integration to query
+     * @return registered layers with a renderer for {@code mod}
+     */
     public static List<LayerManager> getEnabledLayers(SupportedMods mod) {
         return layerManagers.stream()
             .filter(layerManager -> layerManager.isEnabled(mod))
             .collect(Collectors.toList());
     }
 
+    /**
+     * @param mod map integration to query
+     * @return distinct buttons belonging to layers enabled for {@code mod}
+     */
     public static List<ButtonManager> getEnabledButtons(SupportedMods mod) {
         return layerManagers.stream()
             .filter(layerManager -> layerManager.isEnabled(mod))
@@ -63,10 +97,15 @@ public final class NavigatorApi {
             .collect(Collectors.toList());
     }
 
+    /** @return every distinct registered button */
     public static List<ButtonManager> getDistinctButtons() {
         return getDistinctButtons(null);
     }
 
+    /**
+     * @param toExclude optional button to omit
+     * @return every other distinct registered button
+     */
     public static List<ButtonManager> getDistinctButtons(ButtonManager toExclude) {
         return layerManagers.stream()
             .map(LayerManager::getButtonManager)
@@ -75,6 +114,7 @@ public final class NavigatorApi {
             .collect(Collectors.toList());
     }
 
+    /** @return all registered managers that support interaction */
     public static List<InteractableLayerManager> getInteractableLayers() {
         return layerManagers.stream()
             .filter(layerManager -> layerManager instanceof InteractableLayerManager)
@@ -82,11 +122,26 @@ public final class NavigatorApi {
             .collect(Collectors.toList());
     }
 
+    /**
+     * Opens JourneyMap centered on a block position and optionally activates a layer first.
+     *
+     * @param layer  layer to activate, or {@code null}
+     * @param blockX world block X coordinate
+     * @param blockZ world block Z coordinate
+     * @param zoom   JourneyMap zoom, or {@code -1} to keep its current/default zoom
+     */
     public void openJourneyMapAt(@Nullable LayerManager layer, int blockX, int blockZ, int zoom) {
         if (layer != null) layer.activateLayer();
         JourneyMapIntegration.centerOn(blockX, blockZ, zoom);
     }
 
+    /**
+     * Opens JourneyMap centered on a block position without changing its zoom.
+     *
+     * @param layer  layer to activate, or {@code null}
+     * @param blockX world block X coordinate
+     * @param blockZ world block Z coordinate
+     */
     public void openJourneyMapAt(@Nullable LayerManager layer, int blockX, int blockZ) {
         this.openJourneyMapAt(layer, blockX, blockZ, -1);
     }

--- a/src/main/java/com/gtnewhorizons/navigator/api/NavigatorApi.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/NavigatorApi.java
@@ -42,12 +42,14 @@ public final class NavigatorApi {
     /**
      * Registers a layer manager with every applicable map integration.
      * <p>
-     * This method does not deduplicate registrations.
+     * This method does not deduplicate registrations. Registration schedules the layer's initial cache and render
+     * synchronization.
      *
      * @param layerManager The {@link LayerManager} to register.
      */
     public static void registerLayerManager(LayerManager layerManager) {
         layerManagers.add(layerManager);
+        layerManager.forceRefresh();
     }
 
     /**

--- a/src/main/java/com/gtnewhorizons/navigator/api/event/LayerRefreshEvent.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/event/LayerRefreshEvent.java
@@ -1,0 +1,25 @@
+package com.gtnewhorizons.navigator.api.event;
+
+import com.gtnewhorizons.navigator.api.model.layers.LayerManager;
+
+import cpw.mods.fml.common.eventhandler.Event;
+
+/**
+ * Published when a layer requests cache and render-output synchronization.
+ * <p>
+ * The event is posted on FML's common event bus. Consumers should call {@link LayerManager#forceRefresh()} instead of
+ * posting it directly.
+ */
+public final class LayerRefreshEvent extends Event {
+
+    private final LayerManager layerManager;
+
+    public LayerRefreshEvent(LayerManager layerManager) {
+        this.layerManager = layerManager;
+    }
+
+    /** @return layer whose cache and render output need synchronization */
+    public LayerManager getLayerManager() {
+        return layerManager;
+    }
+}

--- a/src/main/java/com/gtnewhorizons/navigator/api/journeymap/drawsteps/JMInteractableStep.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/journeymap/drawsteps/JMInteractableStep.java
@@ -4,9 +4,12 @@ import net.minecraft.client.gui.FontRenderer;
 
 import com.gtnewhorizons.navigator.api.model.steps.InteractableStep;
 
+/** JourneyMap 5-specific interactable step for waypoint-capable locations. */
 public interface JMInteractableStep extends JMRenderStep, InteractableStep {
 
+    /** Draws custom tooltip content in JourneyMap's fullscreen GUI. */
     void drawCustomTooltip(FontRenderer fontRenderer, int mouseX, int mouseY, int displayWidth, int displayHeight);
 
+    /** @return whether the given GUI-space pointer is over this step */
     boolean isMouseOver(int mouseX, int mouseY);
 }

--- a/src/main/java/com/gtnewhorizons/navigator/api/journeymap/drawsteps/JMInteractableStep.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/journeymap/drawsteps/JMInteractableStep.java
@@ -4,7 +4,14 @@ import net.minecraft.client.gui.FontRenderer;
 
 import com.gtnewhorizons.navigator.api.model.steps.InteractableStep;
 
-/** JourneyMap 5-specific interactable step for waypoint-capable locations. */
+/**
+ * JourneyMap 5-specific interactable step for waypoint-capable locations.
+ *
+ * @deprecated Use {@link com.gtnewhorizons.navigator.api.model.steps.UniversalLocationInteractableStep}, or
+ *             {@link com.gtnewhorizons.navigator.api.model.steps.UniversalInteractableStep} when double-click should
+ *             toggle a waypoint. This interface is retained for JourneyMap 5-only integrations.
+ */
+@Deprecated
 public interface JMInteractableStep extends JMRenderStep, InteractableStep {
 
     /** Draws custom tooltip content in JourneyMap's fullscreen GUI. */

--- a/src/main/java/com/gtnewhorizons/navigator/api/journeymap/drawsteps/JMRenderStep.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/journeymap/drawsteps/JMRenderStep.java
@@ -5,8 +5,15 @@ import com.gtnewhorizons.navigator.api.model.steps.RenderStep;
 import journeymap.client.render.draw.DrawStep;
 import journeymap.client.render.map.GridRenderer;
 
+/**
+ * JourneyMap 5-specific render step.
+ * <p>
+ * Prefer {@link com.gtnewhorizons.navigator.api.model.steps.UniversalRenderStep} unless direct JourneyMap 5 drawing
+ * APIs are required. This interface directly links JourneyMap client classes.
+ */
 public interface JMRenderStep extends DrawStep, RenderStep {
 
+    /** Draws using JourneyMap 5's grid renderer and coordinate system. */
     @Override
     void draw(double draggedPixelX, double draggedPixelY, GridRenderer gridRenderer, float drawScale, double fontScale,
         double rotation);

--- a/src/main/java/com/gtnewhorizons/navigator/api/journeymap/drawsteps/JMRenderStep.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/journeymap/drawsteps/JMRenderStep.java
@@ -10,7 +10,11 @@ import journeymap.client.render.map.GridRenderer;
  * <p>
  * Prefer {@link com.gtnewhorizons.navigator.api.model.steps.UniversalRenderStep} unless direct JourneyMap 5 drawing
  * APIs are required. This interface directly links JourneyMap client classes.
+ *
+ * @deprecated Use {@link com.gtnewhorizons.navigator.api.model.steps.UniversalRenderStep}. This interface is retained
+ *             for JourneyMap 5-only integrations.
  */
+@Deprecated
 public interface JMRenderStep extends DrawStep, RenderStep {
 
     /** Draws using JourneyMap 5's grid renderer and coordinate system. */

--- a/src/main/java/com/gtnewhorizons/navigator/api/journeymap/render/JMInteractableLayerRenderer.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/journeymap/render/JMInteractableLayerRenderer.java
@@ -13,6 +13,11 @@ import com.gtnewhorizons.navigator.api.model.layers.InteractableLayer;
 import com.gtnewhorizons.navigator.api.model.layers.InteractableLayerManager;
 import com.gtnewhorizons.navigator.api.model.steps.RenderStep;
 
+/**
+ * JourneyMap 5-specific renderer with hover, tooltip, action-key, and default waypoint double-click handling.
+ * <p>
+ * Prefer {@link com.gtnewhorizons.navigator.api.model.layers.UniversalInteractableRenderer} for new layers.
+ */
 public abstract class JMInteractableLayerRenderer extends JMLayerRenderer implements InteractableLayer {
 
     protected InteractableLayerManager manager;
@@ -53,6 +58,11 @@ public abstract class JMInteractableLayerRenderer extends JMLayerRenderer implem
         return onClickOutsideRenderStep(isDoubleClick, mouseX, mouseY, blockX, blockZ);
     }
 
+    /**
+     * Applies the default double-click waypoint toggle to the hovered step.
+     *
+     * @return whether the click was consumed
+     */
     public boolean onClick(boolean isDoubleClick, int mouseX, int mouseY, int blockX, int blockZ) {
         if (isDoubleClick) {
             if (hoveredDrawStep.getLocation()
@@ -68,6 +78,7 @@ public abstract class JMInteractableLayerRenderer extends JMLayerRenderer implem
         return false;
     }
 
+    /** @return whether a click outside all steps was consumed */
     public boolean onClickOutsideRenderStep(boolean isDoubleClick, int mouseX, int mouseY, int blockX, int blockZ) {
         return false;
     }

--- a/src/main/java/com/gtnewhorizons/navigator/api/journeymap/render/JMInteractableLayerRenderer.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/journeymap/render/JMInteractableLayerRenderer.java
@@ -17,7 +17,11 @@ import com.gtnewhorizons.navigator.api.model.steps.RenderStep;
  * JourneyMap 5-specific renderer with hover, tooltip, action-key, and default waypoint double-click handling.
  * <p>
  * Prefer {@link com.gtnewhorizons.navigator.api.model.layers.UniversalInteractableRenderer} for new layers.
+ *
+ * @deprecated Use {@link com.gtnewhorizons.navigator.api.model.layers.UniversalInteractableRenderer}. This class is
+ *             retained for JourneyMap 5-only integrations.
  */
+@Deprecated
 public abstract class JMInteractableLayerRenderer extends JMLayerRenderer implements InteractableLayer {
 
     protected InteractableLayerManager manager;

--- a/src/main/java/com/gtnewhorizons/navigator/api/journeymap/render/JMLayerRenderer.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/journeymap/render/JMLayerRenderer.java
@@ -9,6 +9,7 @@ import com.gtnewhorizons.navigator.api.model.SupportedMods;
 import com.gtnewhorizons.navigator.api.model.layers.LayerManager;
 import com.gtnewhorizons.navigator.api.model.layers.LayerRenderer;
 
+/** JourneyMap 5-specific renderer. Prefer {@code UniversalLayerRenderer} for new layers. */
 public abstract class JMLayerRenderer extends LayerRenderer {
 
     public JMLayerRenderer(@Nonnull LayerManager manager) {

--- a/src/main/java/com/gtnewhorizons/navigator/api/journeymap/render/JMLayerRenderer.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/journeymap/render/JMLayerRenderer.java
@@ -9,7 +9,13 @@ import com.gtnewhorizons.navigator.api.model.SupportedMods;
 import com.gtnewhorizons.navigator.api.model.layers.LayerManager;
 import com.gtnewhorizons.navigator.api.model.layers.LayerRenderer;
 
-/** JourneyMap 5-specific renderer. Prefer {@code UniversalLayerRenderer} for new layers. */
+/**
+ * JourneyMap 5-specific renderer.
+ *
+ * @deprecated Use {@link com.gtnewhorizons.navigator.api.model.layers.UniversalLayerRenderer}. This class is retained
+ *             for JourneyMap 5-only integrations.
+ */
+@Deprecated
 public abstract class JMLayerRenderer extends LayerRenderer {
 
     public JMLayerRenderer(@Nonnull LayerManager manager) {

--- a/src/main/java/com/gtnewhorizons/navigator/api/journeymap/waypoints/JMWaypointManager.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/journeymap/waypoints/JMWaypointManager.java
@@ -9,6 +9,9 @@ import com.gtnewhorizons.navigator.api.model.waypoints.WaypointManager;
 import com.gtnewhorizons.navigator.api.util.Util;
 import com.gtnewhorizons.navigator.internal.journeymap.v6.JourneyMapV6WaypointManager;
 
+/**
+ * JourneyMap waypoint bridge that uses the legacy model on JourneyMap 5 and delegates to the v2 API on JourneyMap 6.
+ */
 public class JMWaypointManager extends WaypointManager {
 
     private journeymap.client.model.Waypoint jmWaypoint;
@@ -33,6 +36,7 @@ public class JMWaypointManager extends WaypointManager {
         return v6Delegate != null ? v6Delegate.hasWaypoint() : jmWaypoint != null;
     }
 
+    /** @return JourneyMap 5 waypoint, or {@code null}; not used for the JourneyMap 6 delegate */
     public journeymap.client.model.Waypoint getJmWaypoint() {
         return jmWaypoint;
     }

--- a/src/main/java/com/gtnewhorizons/navigator/api/journeymap/waypoints/JMWaypointManager.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/journeymap/waypoints/JMWaypointManager.java
@@ -6,23 +6,31 @@ import com.gtnewhorizons.navigator.api.model.SupportedMods;
 import com.gtnewhorizons.navigator.api.model.layers.InteractableLayerManager;
 import com.gtnewhorizons.navigator.api.model.waypoints.Waypoint;
 import com.gtnewhorizons.navigator.api.model.waypoints.WaypointManager;
+import com.gtnewhorizons.navigator.api.util.Util;
+import com.gtnewhorizons.navigator.internal.journeymap.v6.JourneyMapV6WaypointManager;
 
 public class JMWaypointManager extends WaypointManager {
 
     private journeymap.client.model.Waypoint jmWaypoint;
+    private final WaypointManager v6Delegate;
 
     public JMWaypointManager(InteractableLayerManager layerManager) {
         super(layerManager, SupportedMods.JourneyMap);
+        v6Delegate = Util.isJourneyMapV6Installed() ? new JourneyMapV6WaypointManager(layerManager) : null;
     }
 
     @Override
     public void clearActiveWaypoint() {
+        if (v6Delegate != null) {
+            v6Delegate.clearActiveWaypoint();
+            return;
+        }
         jmWaypoint = null;
     }
 
     @Override
     public boolean hasWaypoint() {
-        return jmWaypoint != null;
+        return v6Delegate != null ? v6Delegate.hasWaypoint() : jmWaypoint != null;
     }
 
     public journeymap.client.model.Waypoint getJmWaypoint() {
@@ -31,6 +39,10 @@ public class JMWaypointManager extends WaypointManager {
 
     @Override
     public void updateActiveWaypoint(Waypoint waypoint) {
+        if (v6Delegate != null) {
+            v6Delegate.updateActiveWaypoint(waypoint);
+            return;
+        }
         if (!hasWaypoint() || waypoint.blockX != jmWaypoint.getX()
             || waypoint.blockY != jmWaypoint.getY()
             || waypoint.blockZ != jmWaypoint.getZ()

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/SupportedMods.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/SupportedMods.java
@@ -5,7 +5,7 @@ import com.gtnewhorizons.navigator.config.ModuleConfig;
 
 public enum SupportedMods {
 
-    JourneyMap(Util.isJourneyMapV5Installed() && ModuleConfig.enableJourneyMapModule),
+    JourneyMap(Util.isJourneyMapInstalled() && ModuleConfig.enableJourneyMapModule),
     XaeroWorldMap(Util.isXaerosWorldMapInstalled() && ModuleConfig.enableXaeroWorldMapModule),
     XaeroMiniMap(Util.isXaerosMinimapInstalled() && ModuleConfig.enableXaeroMinimapModule),
     NONE(false);

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/SupportedMods.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/SupportedMods.java
@@ -3,6 +3,7 @@ package com.gtnewhorizons.navigator.api.model;
 import com.gtnewhorizons.navigator.api.util.Util;
 import com.gtnewhorizons.navigator.config.ModuleConfig;
 
+/** Map integrations supported by Navigator and their process-lifetime availability. */
 public enum SupportedMods {
 
     JourneyMap(Util.isJourneyMapInstalled() && ModuleConfig.enableJourneyMapModule),
@@ -16,6 +17,11 @@ public enum SupportedMods {
         this.enabled = enabled;
     }
 
+    /**
+     * Returns whether the corresponding mod is installed and its Navigator module is enabled.
+     *
+     * @return integration availability cached during class initialization
+     */
     public boolean isEnabled() {
         return enabled;
     }

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/buttons/ButtonManager.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/buttons/ButtonManager.java
@@ -7,6 +7,13 @@ import com.gtnewhorizons.navigator.api.model.SupportedMods;
 
 import it.unimi.dsi.fastutil.booleans.BooleanConsumer;
 
+/**
+ * Logical toggle shared by a layer across map integrations.
+ * <p>
+ * Activating one button deactivates every other distinct registered Navigator button. A consumer callback may be
+ * installed with {@link #setOnToggle(BooleanConsumer)}; the owning layer manager installs a separate internal
+ * notification callback.
+ */
 public abstract class ButtonManager {
 
     protected boolean isActive = false;
@@ -15,25 +22,37 @@ public abstract class ButtonManager {
 
     /**
      * @param mod   the mod requesting the icon
-     * @param theme the theme of the icon. "Victorian" or "Vault" for Journeymap, empty string for Xaeros.
+     * @param theme current map UI theme; JourneyMap supplies its theme name and Xaero normally supplies an empty string
      * @return the {@link ResourceLocation} of the icon to be displayed on the button
      */
     public abstract ResourceLocation getIcon(SupportedMods mod, String theme);
 
+    /** @return localized or display-ready tooltip text for the button */
     public abstract String getButtonText();
 
+    /**
+     * @param onToggle consumer callback invoked after the active state changes
+     */
     public final void setOnToggle(BooleanConsumer onToggle) {
         this.onToggle = onToggle;
     }
 
+    /**
+     * Installs the owning manager's state callback.
+     * <p>
+     * Consumers normally do not call this method; {@link com.gtnewhorizons.navigator.api.model.layers.LayerManager}
+     * configures it in its constructor.
+     */
     public final void setLayerNotify(BooleanConsumer layerToggled) {
         this.notifyLayerToggled = layerToggled;
     }
 
+    /** @return current logical active state */
     public boolean isActive() {
         return isActive;
     }
 
+    /** Activates this button after deactivating other distinct Navigator buttons. */
     public void activate() {
         NavigatorApi.getDistinctButtons(this)
             .forEach(ButtonManager::deactivate);
@@ -47,6 +66,7 @@ public abstract class ButtonManager {
         }
     }
 
+    /** Deactivates this button and notifies callbacks. */
     public void deactivate() {
         isActive = false;
         if (onToggle != null) {
@@ -58,6 +78,7 @@ public abstract class ButtonManager {
         }
     }
 
+    /** Toggles between {@link #activate()} and {@link #deactivate()}. */
     public void toggle() {
         if (isActive) {
             deactivate();

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/buttons/ButtonManager.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/buttons/ButtonManager.java
@@ -22,7 +22,8 @@ public abstract class ButtonManager {
 
     /**
      * @param mod   the mod requesting the icon
-     * @param theme current map UI theme; JourneyMap supplies its theme name and Xaero normally supplies an empty string
+     * @param theme current map UI theme; JourneyMap 5 supplies its name, while JourneyMap 6 and Xaero supply an empty
+     *              string
      * @return the {@link ResourceLocation} of the icon to be displayed on the button
      */
     public abstract ResourceLocation getIcon(SupportedMods mod, String theme);

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/layers/InteractableLayer.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/layers/InteractableLayer.java
@@ -4,14 +4,23 @@ import java.util.List;
 
 import net.minecraft.client.gui.FontRenderer;
 
+/** Input and tooltip contract implemented by renderers that can consume map interaction. */
 public interface InteractableLayer {
 
+    /** Updates the renderer's hovered step from GUI-space mouse coordinates. */
     void onMouseMove(int mouseX, int mouseY);
 
+    /**
+     * Dispatches a map click.
+     *
+     * @return {@code true} when Navigator consumed the click
+     */
     boolean onMapClick(boolean isDoubleClick, int mouseX, int mouseY, int blockX, int blockZ);
 
+    /** @return tooltip lines for the current hovered step */
     List<String> getTooltip();
 
+    /** Draws any step-specific custom tooltip content. */
     void drawCustomTooltip(FontRenderer fontRenderer, int mouseX, int mouseY, int displayWidth, int displayHeight);
 
     /**

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/layers/InteractableLayerManager.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/layers/InteractableLayerManager.java
@@ -12,12 +12,21 @@ import com.gtnewhorizons.navigator.api.model.locations.IWaypointAndLocationProvi
 import com.gtnewhorizons.navigator.api.model.waypoints.Waypoint;
 import com.gtnewhorizons.navigator.api.model.waypoints.WaypointManager;
 
+/**
+ * Layer manager that supports clickable render steps and an optional active waypoint.
+ * <p>
+ * Plain {@link ILocationProvider} elements may be interactive. Waypoint synchronization is only applied to elements
+ * that implement {@link IWaypointAndLocationProvider}.
+ */
 public abstract class InteractableLayerManager extends LayerManager {
 
     protected final Map<SupportedMods, WaypointManager> waypointManagers = new EnumMap<>(SupportedMods.class);
 
     protected Waypoint activeWaypoint = null;
 
+    /**
+     * @param buttonManager shared logical button controlling this layer
+     */
     public InteractableLayerManager(ButtonManager buttonManager) {
         super(buttonManager);
         for (SupportedMods mod : SupportedMods.values()) {
@@ -31,6 +40,8 @@ public abstract class InteractableLayerManager extends LayerManager {
     }
 
     /**
+     * Creates an interactable or normal renderer for an installed integration.
+     *
      * @param manager This layer manager
      * @param mod     The mod to add the layer renderer for
      * @return The {@link LayerRenderer} implementation for the mod or null if none
@@ -38,6 +49,8 @@ public abstract class InteractableLayerManager extends LayerManager {
     protected abstract @Nullable LayerRenderer addLayerRenderer(InteractableLayerManager manager, SupportedMods mod);
 
     /**
+     * Optionally creates the bridge used to publish Navigator's active waypoint to a map mod.
+     *
      * @param manager This layer manager
      * @param mod     The mod to add the waypoint manager for
      * @return The {@link WaypointManager} implementation for the mod or null if none
@@ -47,9 +60,9 @@ public abstract class InteractableLayerManager extends LayerManager {
     }
 
     /**
-     * Update the information contained in the {@link IWaypointAndLocationProvider}
+     * Updates a cached waypoint-capable location.
      * <p>
-     * If this information is updated outside of this method {@link #forceRefresh()} should be called
+     * Plain locations bypass this overload. If information changes outside this method, call {@link #forceRefresh()}.
      *
      * @param location The location to update
      */
@@ -61,6 +74,11 @@ public abstract class InteractableLayerManager extends LayerManager {
         return addLayerRenderer(this, mod);
     }
 
+    /**
+     * Sets the active waypoint, updates visible waypoint-capable locations, and synchronizes map waypoint managers.
+     *
+     * @param waypoint new active waypoint
+     */
     public void setActiveWaypoint(Waypoint waypoint) {
         activeWaypoint = waypoint;
         getVisibleLocations().forEach(element -> {
@@ -72,6 +90,7 @@ public abstract class InteractableLayerManager extends LayerManager {
             .forEach(translator -> translator.updateActiveWaypoint(waypoint));
     }
 
+    /** Clears the active waypoint and notifies visible waypoint-capable locations and map managers. */
     public void clearActiveWaypoint() {
         activeWaypoint = null;
         getVisibleLocations().forEach(element -> {
@@ -83,10 +102,15 @@ public abstract class InteractableLayerManager extends LayerManager {
             .forEach(WaypointManager::clearActiveWaypoint);
     }
 
+    /** @return whether this manager currently has an active waypoint */
     public boolean hasActiveWaypoint() {
         return activeWaypoint != null;
     }
 
+    /**
+     * @param map map integration
+     * @return its waypoint manager, or {@code null}
+     */
     public @Nullable WaypointManager getWaypointManager(SupportedMods map) {
         return waypointManagers.get(map);
     }

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/layers/InteractableLayerManager.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/layers/InteractableLayerManager.java
@@ -1,6 +1,5 @@
 package com.gtnewhorizons.navigator.api.model.layers;
 
-import java.util.Collection;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -64,14 +63,22 @@ public abstract class InteractableLayerManager extends LayerManager {
 
     public void setActiveWaypoint(Waypoint waypoint) {
         activeWaypoint = waypoint;
-        getVisibleLocations().forEach(element -> element.onWaypointUpdated(waypoint));
+        getVisibleLocations().forEach(element -> {
+            if (element instanceof IWaypointAndLocationProvider waypointLoc) {
+                waypointLoc.onWaypointUpdated(waypoint);
+            }
+        });
         waypointManagers.values()
             .forEach(translator -> translator.updateActiveWaypoint(waypoint));
     }
 
     public void clearActiveWaypoint() {
         activeWaypoint = null;
-        getVisibleLocations().forEach(IWaypointAndLocationProvider::onWaypointCleared);
+        getVisibleLocations().forEach(element -> {
+            if (element instanceof IWaypointAndLocationProvider waypointLoc) {
+                waypointLoc.onWaypointCleared();
+            }
+        });
         waypointManagers.values()
             .forEach(WaypointManager::clearActiveWaypoint);
     }
@@ -94,9 +101,4 @@ public abstract class InteractableLayerManager extends LayerManager {
         }
     }
 
-    @Override
-    @SuppressWarnings("unchecked")
-    public Collection<IWaypointAndLocationProvider> getVisibleLocations() {
-        return (Collection<IWaypointAndLocationProvider>) super.getVisibleLocations();
-    }
 }

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/layers/InteractableLayerManager.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/layers/InteractableLayerManager.java
@@ -120,6 +120,8 @@ public abstract class InteractableLayerManager extends LayerManager {
         if (location instanceof IWaypointAndLocationProvider waypointLoc) {
             if (hasActiveWaypoint()) {
                 waypointLoc.onWaypointUpdated(activeWaypoint);
+            } else if (waypointLoc.isActiveAsWaypoint()) {
+                waypointLoc.onWaypointCleared();
             }
             updateElement(waypointLoc);
         }

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/layers/LayerManager.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/layers/LayerManager.java
@@ -23,6 +23,12 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 
+/**
+ * Owns one logical layer's location cache, viewport discovery, button state, search hook, and map renderers.
+ * <p>
+ * Locations are cached per dimension and discovered by chunk. A recache uses the larger of the active minimap and
+ * fullscreen viewports, calls the update hooks, and then gives every renderer the same visible location set.
+ */
 @SuppressWarnings({ "DeprecatedIsStillUsed", "unused" })
 public abstract class LayerManager {
 
@@ -44,6 +50,11 @@ public abstract class LayerManager {
     private boolean hasSearchField;
     private long refreshVersion;
 
+    /**
+     * Creates a layer and its renderers for currently enabled map integrations.
+     *
+     * @param buttonManager shared logical button controlling this layer
+     */
     public LayerManager(ButtonManager buttonManager) {
         this.buttonManager = buttonManager;
         buttonManager.setLayerNotify(this::onLayerToggled);
@@ -57,6 +68,10 @@ public abstract class LayerManager {
     }
 
     /**
+     * Creates the renderer used by one installed map integration.
+     * <p>
+     * Return a universal renderer for map-neutral behavior or {@code null} when this layer does not support the map.
+     *
      * @param manager This layer manager
      * @param mod     The mod to add the layer renderer for
      * @return The {@link LayerRenderer} implementation for the mod or null if none
@@ -64,6 +79,8 @@ public abstract class LayerManager {
     protected abstract @Nullable LayerRenderer addLayerRenderer(LayerManager manager, SupportedMods mod);
 
     /**
+     * Discovers one location for a chunk that is not already cached.
+     *
      * @param chunkX The chunk x coordinate
      * @param chunkZ The chunk z coordinate
      * @param dim    The dimension id
@@ -74,7 +91,10 @@ public abstract class LayerManager {
     }
 
     /**
+     * Alternative discovery hook using a packed chunk key.
+     *
      * @param packedChunk A long packed with {@link Util#packChunkToLocation(int, int)}
+     * @param dim         dimension id
      * @return The {@link ILocationProvider} for the chunk or null if none
      */
     protected @Nullable ILocationProvider generateLocation(long packedChunk, int dim) {
@@ -82,18 +102,18 @@ public abstract class LayerManager {
     }
 
     /**
-     * Update the information contained in the {@link ILocationProvider}
+     * Updates a cached visible location during each recache.
      * <p>
-     * If this information is updated outside of this method {@link #forceRefresh()} should be called
+     * If the information changes outside this method, call {@link #forceRefresh()}.
      *
      * @param location The location to update
      */
     public void updateElement(ILocationProvider location) {}
 
     /**
-     * Needed for layers where a location represents an area larger than a single chunk
+     * Expands discovery around the viewport for elements larger than one chunk.
      *
-     * @return The width/height of the element in chunks
+     * @return extra chunks added on every side of the discovery bounds
      */
     public int getElementSize() {
         return 0;
@@ -140,59 +160,105 @@ public abstract class LayerManager {
         return null;
     }
 
+    /** @return whether the shared layer button is active */
     public boolean isLayerActive() {
         return buttonManager.isActive();
     }
 
+    /** Activates this layer and deactivates other distinct Navigator buttons. */
     public void activateLayer() {
         buttonManager.activate();
     }
 
+    /** Deactivates this layer. */
     public void deactivateLayer() {
         buttonManager.deactivate();
     }
 
+    /** Toggles this layer. */
     public void toggleLayer() {
         buttonManager.toggle();
     }
 
+    /**
+     * Requests renderer/native-overlay synchronization after external data changes.
+     * <p>
+     * Repeated calls increment the refresh version and should be avoided when nothing changed.
+     */
     public void forceRefresh() {
         forceRefresh = true;
         refreshVersion++;
     }
 
+    /** @return monotonically increasing version incremented by {@link #forceRefresh()} */
     public long getRefreshVersion() {
         return refreshVersion;
     }
 
+    /**
+     * Records that a supported fullscreen map opened and calls {@link #onOpenMap()}.
+     *
+     * @param mod map integration that opened
+     */
     public final void onGuiOpened(SupportedMods mod) {
         openModGui = mod;
         onOpenMap();
     }
 
+    /**
+     * Records that a supported fullscreen map closed and calls {@link #onCloseMap()}.
+     *
+     * @param mod map integration that closed
+     */
     public final void onGuiClosed(SupportedMods mod) {
         openModGui = SupportedMods.NONE;
         onCloseMap();
     }
 
+    /** Consumer hook called after a supported fullscreen map opens. */
     public void onOpenMap() {}
 
+    /** Consumer hook called after a supported fullscreen map closes. */
     public void onCloseMap() {}
 
+    /** @return currently open map integration, or {@link SupportedMods#NONE} */
     public final SupportedMods getOpenModGui() {
         return openModGui;
     }
 
+    /**
+     * Recaches a square minimap viewport.
+     *
+     * @param centerBlockX viewport center X
+     * @param centerBlockZ viewport center Z
+     * @param blockRadius  viewport radius in blocks
+     */
     public void recacheMiniMap(int centerBlockX, int centerBlockZ, int blockRadius) {
         recacheMiniMap(centerBlockX, centerBlockZ, blockRadius, blockRadius);
     }
 
+    /**
+     * Recaches a rectangular minimap viewport.
+     *
+     * @param centerBlockX viewport center X
+     * @param centerBlockZ viewport center Z
+     * @param blockWidth   viewport width in blocks
+     * @param blockHeight  viewport height in blocks
+     */
     public void recacheMiniMap(int centerBlockX, int centerBlockZ, int blockWidth, int blockHeight) {
         miniMapWidth = blockWidth;
         miniMapHeight = blockHeight;
         recacheVisibleElements(centerBlockX, centerBlockZ);
     }
 
+    /**
+     * Recaches a fullscreen viewport.
+     *
+     * @param centerBlockX viewport center X
+     * @param centerBlockZ viewport center Z
+     * @param blockWidth   viewport width in blocks
+     * @param blockHeight  viewport height in blocks
+     */
     public void recacheFullscreenMap(int centerBlockX, int centerBlockZ, int blockWidth, int blockHeight) {
         fullscreenMapWidth = blockWidth;
         fullscreenMapHeight = blockHeight;
@@ -251,22 +317,53 @@ public abstract class LayerManager {
         onUpdatePost(chunkMinX, chunkMaxX, chunkMinZ, chunkMaxZ);
     }
 
+    /**
+     * Called when the shared layer button changes.
+     * <p>
+     * The default implementation clears all caches when disabled. Overrides should call {@code super} unless they
+     * deliberately retain renderer state.
+     *
+     * @param toEnable new active state
+     */
     public void onLayerToggled(boolean toEnable) {
         if (!toEnable) {
             clearFull();
         }
     }
 
+    /**
+     * Runs before chunk discovery/update for a viewport recache.
+     *
+     * @param minX inclusive minimum chunk X
+     * @param maxX inclusive maximum chunk X
+     * @param minZ inclusive minimum chunk Z
+     * @param maxZ inclusive maximum chunk Z
+     */
     public void onUpdatePre(int minX, int maxX, int minZ, int maxZ) {}
 
+    /**
+     * Runs after visible locations and renderer steps have been refreshed.
+     *
+     * @param minX inclusive minimum chunk X
+     * @param maxX inclusive maximum chunk X
+     * @param minZ inclusive minimum chunk Z
+     * @param maxZ inclusive maximum chunk Z
+     */
     public void onUpdatePost(int minX, int maxX, int minZ, int maxZ) {}
 
+    /**
+     * Queues a cached location and its render steps for removal on the next recache.
+     *
+     * @param location location to remove
+     */
     public final void removeLocation(ILocationProvider location) {
         removeQueue.add(location);
         forceRefresh();
     }
 
     /**
+     * Queues a cached location for removal by identity.
+     *
      * @param location must be a long packed with {@link Util#packChunkToLocation(int, int)}
      */
     public final void removeLocation(long location) {
@@ -275,30 +372,50 @@ public abstract class LayerManager {
         removeLocation(loc);
     }
 
+    /** Queues the location cached under a chunk coordinate for removal. */
     public final void removeLocation(int chunkX, int chunkZ) {
         removeLocation(Util.packChunkToLocation(chunkX, chunkZ));
     }
 
+    /**
+     * Inserts an already-created location into the current dimension cache.
+     *
+     * @param location location whose {@link ILocationProvider#toLong()} is its cache key
+     */
     public final void addExtraLocation(ILocationProvider location) {
         currentDimCache.put(location.toLong(), location);
     }
 
+    /** @return shared logical button */
     public ButtonManager getButtonManager() {
         return buttonManager;
     }
 
+    /**
+     * @param map map integration
+     * @return renderer registered for that integration, or {@code null}
+     */
     public LayerRenderer getLayerRenderer(SupportedMods map) {
         return layerRenderer.get(map);
     }
 
+    /**
+     * @return manager-owned set of locations visible in the latest combined viewport
+     */
     public Collection<ILocationProvider> getVisibleLocations() {
         return visibleLocations;
     }
 
+    /** @return manager-owned cached locations for the current dimension */
     public Collection<? extends ILocationProvider> getCachedLocations() {
         return getCurrentDimCache().values();
     }
 
+    /**
+     * Returns or initializes the current dimension cache.
+     *
+     * @return mutable location map keyed by stable location identity
+     */
     public Long2ObjectMap<ILocationProvider> getCurrentDimCache() {
         if (currentDimCache == null) {
             currentDimCache = dimCachedLocations.computeIfAbsent(currentDim, k -> new Long2ObjectOpenHashMap<>());
@@ -323,11 +440,13 @@ public abstract class LayerManager {
             .forEach(renderer -> renderer.setDimCache(currentDim));
     }
 
+    /** Schedules the current dimension's locations and render steps for clearing. */
     public void clearCurrentCache() {
         clearCurrent = true;
         forceRefresh();
     }
 
+    /** Schedules every dimension's locations and render steps for clearing. */
     public void clearFullCache() {
         clearFull = true;
         forceRefresh();
@@ -350,14 +469,25 @@ public abstract class LayerManager {
             .forEach(LayerRenderer::clearFullCache);
     }
 
+    /**
+     * Enables or disables Navigator's search field for this layer.
+     *
+     * @param hasSearchField whether the layer accepts search text
+     */
     protected void setHasSearchField(boolean hasSearchField) {
         this.hasSearchField = hasSearchField;
     }
 
+    /** @return whether this layer requests the map search field */
     public boolean hasSearchField() {
         return hasSearchField;
     }
 
+    /**
+     * Receives search text changes from a supported fullscreen map.
+     *
+     * @param searchString current non-null search text
+     */
     public void onSearch(@NotNull String searchString) {}
 
     /**

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/layers/LayerManager.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/layers/LayerManager.java
@@ -254,10 +254,10 @@ public abstract class LayerManager {
      *
      * @param centerBlockX viewport center X
      * @param centerBlockZ viewport center Z
-     * @param blockRadius  viewport radius in blocks
+     * @param blockWidth   viewport width and height in blocks
      */
-    public void recacheMiniMap(int centerBlockX, int centerBlockZ, int blockRadius) {
-        recacheMiniMap(centerBlockX, centerBlockZ, blockRadius, blockRadius);
+    public void recacheMiniMap(int centerBlockX, int centerBlockZ, int blockWidth) {
+        recacheMiniMap(centerBlockX, centerBlockZ, blockWidth, blockWidth);
     }
 
     /**

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/layers/LayerManager.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/layers/LayerManager.java
@@ -330,11 +330,12 @@ public abstract class LayerManager {
         onUpdatePre(chunkMinX, chunkMaxX, chunkMinZ, chunkMaxZ);
 
         visibleLocations.clear();
+        int elementMargin = getElementSize() << 4;
         Collection<? extends ILocationProvider> generatedLocations = generateVisibleLocations(
-            minBlockX,
-            minBlockZ,
-            maxBlockX,
-            maxBlockZ,
+            minBlockX - elementMargin,
+            minBlockZ - elementMargin,
+            maxBlockX + elementMargin,
+            maxBlockZ + elementMargin,
             currentDim);
         if (generatedLocations != null) {
             for (ILocationProvider generated : generatedLocations) {

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/layers/LayerManager.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/layers/LayerManager.java
@@ -26,8 +26,9 @@ import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 /**
  * Owns one logical layer's location cache, viewport discovery, button state, search hook, and map renderers.
  * <p>
- * Locations are cached per dimension and discovered by chunk. A recache uses the larger of the active minimap and
- * fullscreen viewports, calls the update hooks, and then gives every renderer the same visible location set.
+ * Locations are cached per dimension and discovered by chunk or as a viewport collection. A recache uses the larger
+ * of the active minimap and fullscreen viewports, calls the update hooks, and then gives every renderer the same
+ * visible location set.
  */
 @SuppressWarnings({ "DeprecatedIsStillUsed", "unused" })
 public abstract class LayerManager {
@@ -98,6 +99,26 @@ public abstract class LayerManager {
      * @return The {@link ILocationProvider} for the chunk or null if none
      */
     protected @Nullable ILocationProvider generateLocation(long packedChunk, int dim) {
+        return null;
+    }
+
+    /**
+     * Discovers every location in the current viewport when a layer can contain multiple elements per chunk.
+     * <p>
+     * Return {@code null} to use the normal chunk-by-chunk {@link #generateLocation(int, int, int)} path. Each
+     * returned location must provide a stable, layer-unique {@link ILocationProvider#toLong()} identity. Navigator
+     * retains the first object for an identity and calls {@link #updateElement(ILocationProvider)} on it during later
+     * recaches.
+     *
+     * @param minBlockX inclusive minimum block X
+     * @param minBlockZ inclusive minimum block Z
+     * @param maxBlockX inclusive maximum block X
+     * @param maxBlockZ inclusive maximum block Z
+     * @param dimension current dimension
+     * @return visible locations, an empty collection for none, or {@code null} to use chunk discovery
+     */
+    protected @Nullable Collection<? extends ILocationProvider> generateVisibleLocations(int minBlockX, int minBlockZ,
+        int maxBlockX, int maxBlockZ, int dimension) {
         return null;
     }
 
@@ -302,13 +323,32 @@ public abstract class LayerManager {
         onUpdatePre(chunkMinX, chunkMaxX, chunkMinZ, chunkMaxZ);
 
         visibleLocations.clear();
-        for (int chunkX = chunkMinX; chunkX <= chunkMaxX; chunkX++) {
-            for (int chunkZ = chunkMinZ; chunkZ <= chunkMaxZ; chunkZ++) {
-                ILocationProvider location = getOrCreateLocation(chunkX, chunkZ);
-                if (location == null) continue;
-
+        Collection<? extends ILocationProvider> generatedLocations = generateVisibleLocations(
+            minBlockX,
+            minBlockZ,
+            maxBlockX,
+            maxBlockZ,
+            currentDim);
+        if (generatedLocations != null) {
+            for (ILocationProvider generated : generatedLocations) {
+                if (generated == null || generated.getDimensionId() != currentDim) continue;
+                ILocationProvider location = currentDimCache.get(generated.toLong());
+                if (location == null) {
+                    location = generated;
+                    currentDimCache.put(location.toLong(), location);
+                }
                 updateElement(location);
                 visibleLocations.add(location);
+            }
+        } else {
+            for (int chunkX = chunkMinX; chunkX <= chunkMaxX; chunkX++) {
+                for (int chunkZ = chunkMinZ; chunkZ <= chunkMaxZ; chunkZ++) {
+                    ILocationProvider location = getOrCreateLocation(chunkX, chunkZ);
+                    if (location == null) continue;
+
+                    updateElement(location);
+                    visibleLocations.add(location);
+                }
             }
         }
 

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/layers/LayerManager.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/layers/LayerManager.java
@@ -403,9 +403,9 @@ public abstract class LayerManager {
      *
      * @param location location to remove
      */
-    public final void removeLocation(ILocationProvider location) {
+    public final void invalidateLocation(ILocationProvider location) {
         if (location.getDimensionId() != currentDim) {
-            removeLocation(location.getDimensionId(), location.toLong());
+            invalidateLocation(location.getDimensionId(), location.toLong());
             return;
         }
         removeQueue.add(location);
@@ -417,13 +417,13 @@ public abstract class LayerManager {
      *
      * @param location stable location identity, normally from {@link ILocationProvider#toLong()}
      */
-    public final void removeLocation(long location) {
-        removeLocation(currentDim, location);
+    public final void invalidateLocation(long location) {
+        invalidateLocation(currentDim, location);
     }
 
-    /** Queues the location cached under a chunk coordinate for removal. */
-    public final void removeLocation(int chunkX, int chunkZ) {
-        removeLocation(Util.packChunkToLocation(chunkX, chunkZ));
+    /** Invalidates the location cached under a chunk coordinate. */
+    public final void invalidateLocation(int chunkX, int chunkZ) {
+        invalidateLocation(Util.packChunkToLocation(chunkX, chunkZ));
     }
 
     /**
@@ -432,11 +432,11 @@ public abstract class LayerManager {
      * Current-dimension removal is queued to keep interaction iteration safe. Other dimensions can be invalidated
      * immediately because their render steps are not active.
      */
-    public final void removeLocation(int dimension, long location) {
+    public final void invalidateLocation(int dimension, long location) {
         if (dimension == currentDim) {
             ILocationProvider cached = currentDimCache == null ? null : currentDimCache.get(location);
             if (cached != null) {
-                removeLocation(cached);
+                invalidateLocation(cached);
                 return;
             }
         } else {
@@ -449,8 +449,40 @@ public abstract class LayerManager {
     }
 
     /** Invalidates a location in one dimension by chunk coordinate. */
+    public final void invalidateLocation(int dimension, int chunkX, int chunkZ) {
+        invalidateLocation(dimension, Util.packChunkToLocation(chunkX, chunkZ));
+    }
+
+    /**
+     * @deprecated Use {@link #invalidateLocation(ILocationProvider)}; this only invalidates Navigator's cached copy.
+     */
+    @Deprecated
+    public final void removeLocation(ILocationProvider location) {
+        invalidateLocation(location);
+    }
+
+    /** @deprecated Use {@link #invalidateLocation(long)}. */
+    @Deprecated
+    public final void removeLocation(long location) {
+        invalidateLocation(location);
+    }
+
+    /** @deprecated Use {@link #invalidateLocation(int, int)}. */
+    @Deprecated
+    public final void removeLocation(int chunkX, int chunkZ) {
+        invalidateLocation(chunkX, chunkZ);
+    }
+
+    /** @deprecated Use {@link #invalidateLocation(int, long)}. */
+    @Deprecated
+    public final void removeLocation(int dimension, long location) {
+        invalidateLocation(dimension, location);
+    }
+
+    /** @deprecated Use {@link #invalidateLocation(int, int, int)}. */
+    @Deprecated
     public final void removeLocation(int dimension, int chunkX, int chunkZ) {
-        removeLocation(dimension, Util.packChunkToLocation(chunkX, chunkZ));
+        invalidateLocation(dimension, chunkX, chunkZ);
     }
 
     /**

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/layers/LayerManager.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/layers/LayerManager.java
@@ -14,11 +14,13 @@ import net.minecraft.client.Minecraft;
 
 import org.jetbrains.annotations.NotNull;
 
+import com.gtnewhorizons.navigator.api.event.LayerRefreshEvent;
 import com.gtnewhorizons.navigator.api.model.SupportedMods;
 import com.gtnewhorizons.navigator.api.model.buttons.ButtonManager;
 import com.gtnewhorizons.navigator.api.model.locations.ILocationProvider;
 import com.gtnewhorizons.navigator.api.util.Util;
 
+import cpw.mods.fml.common.FMLCommonHandler;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
@@ -50,7 +52,6 @@ public abstract class LayerManager {
     private boolean refreshDim = true;
     private boolean clearFull, clearCurrent;
     private boolean hasSearchField;
-    private long refreshVersion;
 
     /**
      * Creates a layer and its renderers for currently enabled map integrations.
@@ -59,7 +60,10 @@ public abstract class LayerManager {
      */
     public LayerManager(ButtonManager buttonManager) {
         this.buttonManager = buttonManager;
-        buttonManager.setLayerNotify(this::onLayerToggled);
+        buttonManager.setLayerNotify(toEnable -> {
+            onLayerToggled(toEnable);
+            forceRefresh();
+        });
         for (SupportedMods mod : SupportedMods.values()) {
             if (!mod.isEnabled()) continue;
 
@@ -205,17 +209,14 @@ public abstract class LayerManager {
     /**
      * Requests renderer/native-overlay synchronization after external data changes.
      * <p>
-     * The legacy flag is consumed by the next successful recache. Repeated calls increment the refresh version and
-     * should be avoided when nothing changed.
+     * The legacy flag is consumed by the next successful recache. A layer refresh event lets retained-overlay
+     * integrations synchronize without polling; integrations may coalesce repeated requests.
      */
     public void forceRefresh() {
         forceRefresh = true;
-        refreshVersion++;
-    }
-
-    /** @return monotonically increasing version incremented by {@link #forceRefresh()} */
-    public long getRefreshVersion() {
-        return refreshVersion;
+        FMLCommonHandler.instance()
+            .bus()
+            .post(new LayerRefreshEvent(this));
     }
 
     /**
@@ -311,9 +312,12 @@ public abstract class LayerManager {
 
         if (!removeQueue.isEmpty()) {
             for (ILocationProvider location : removeQueue) {
+                int dimension = location.getDimensionId();
+                long key = location.toLong();
                 layerRenderer.values()
-                    .forEach(layer -> layer.removeRenderStep(location.toLong()));
-                currentDimCache.remove(location.toLong());
+                    .forEach(layer -> layer.removeRenderStep(dimension, key));
+                Long2ObjectMap<ILocationProvider> cache = dimCachedLocations.get(dimension);
+                if (cache != null) cache.remove(key);
             }
             removeQueue.clear();
         }
@@ -400,6 +404,10 @@ public abstract class LayerManager {
      * @param location location to remove
      */
     public final void removeLocation(ILocationProvider location) {
+        if (location.getDimensionId() != currentDim) {
+            removeLocation(location.getDimensionId(), location.toLong());
+            return;
+        }
         removeQueue.add(location);
         forceRefresh();
     }
@@ -410,10 +418,7 @@ public abstract class LayerManager {
      * @param location stable location identity, normally from {@link ILocationProvider#toLong()}
      */
     public final void removeLocation(long location) {
-        if (currentDimCache == null) return;
-        ILocationProvider loc = currentDimCache.get(location);
-        if (loc == null) return;
-        removeLocation(loc);
+        removeLocation(currentDim, location);
     }
 
     /** Queues the location cached under a chunk coordinate for removal. */
@@ -422,12 +427,40 @@ public abstract class LayerManager {
     }
 
     /**
-     * Inserts an already-created location into the current dimension cache.
+     * Invalidates a stable location identity in one dimension and schedules synchronization.
+     * <p>
+     * Current-dimension removal is queued to keep interaction iteration safe. Other dimensions can be invalidated
+     * immediately because their render steps are not active.
+     */
+    public final void removeLocation(int dimension, long location) {
+        if (dimension == currentDim) {
+            ILocationProvider cached = currentDimCache == null ? null : currentDimCache.get(location);
+            if (cached != null) {
+                removeLocation(cached);
+                return;
+            }
+        } else {
+            Long2ObjectMap<ILocationProvider> cache = dimCachedLocations.get(dimension);
+            if (cache != null) cache.remove(location);
+            layerRenderer.values()
+                .forEach(renderer -> renderer.removeRenderStep(dimension, location));
+        }
+        forceRefresh();
+    }
+
+    /** Invalidates a location in one dimension by chunk coordinate. */
+    public final void removeLocation(int dimension, int chunkX, int chunkZ) {
+        removeLocation(dimension, Util.packChunkToLocation(chunkX, chunkZ));
+    }
+
+    /**
+     * Inserts an already-created location into the current dimension cache and schedules synchronization.
      *
      * @param location location whose {@link ILocationProvider#toLong()} is its cache key
      */
     public final void addExtraLocation(ILocationProvider location) {
-        currentDimCache.put(location.toLong(), location);
+        getCurrentDimCache().put(location.toLong(), location);
+        forceRefresh();
     }
 
     /** @return shared logical button */

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/layers/LayerManager.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/layers/LayerManager.java
@@ -46,7 +46,7 @@ public abstract class LayerManager {
     private int fullscreenMapWidth = 0;
     private int fullscreenMapHeight = 0;
     private int currentDim;
-    private SupportedMods openModGui;
+    private SupportedMods openModGui = SupportedMods.NONE;
     private boolean refreshDim = true;
     private boolean clearFull, clearCurrent;
     private boolean hasSearchField;
@@ -205,7 +205,8 @@ public abstract class LayerManager {
     /**
      * Requests renderer/native-overlay synchronization after external data changes.
      * <p>
-     * Repeated calls increment the refresh version and should be avoided when nothing changed.
+     * The legacy flag is consumed by the next successful recache. Repeated calls increment the refresh version and
+     * should be avoided when nothing changed.
      */
     public void forceRefresh() {
         forceRefresh = true;
@@ -290,6 +291,7 @@ public abstract class LayerManager {
     private void recacheVisibleElements(int centerBlockX, int centerBlockZ) {
         Minecraft minecraft = Minecraft.getMinecraft();
         if (minecraft.thePlayer == null || minecraft.theWorld == null) return;
+        forceRefresh = false;
 
         int radiusBlockX = (Math.max(miniMapWidth, fullscreenMapWidth) + 1) >> 1;
         int radiusBlockZ = (Math.max(miniMapHeight, fullscreenMapHeight) + 1) >> 1;

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/layers/LayerManager.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/layers/LayerManager.java
@@ -291,7 +291,7 @@ public abstract class LayerManager {
         return layerRenderer.get(map);
     }
 
-    public Collection<? extends ILocationProvider> getVisibleLocations() {
+    public Collection<ILocationProvider> getVisibleLocations() {
         return visibleLocations;
     }
 

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/layers/LayerManager.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/layers/LayerManager.java
@@ -3,6 +3,7 @@ package com.gtnewhorizons.navigator.api.model.layers;
 import java.util.Collection;
 import java.util.EnumMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -37,7 +38,7 @@ public abstract class LayerManager {
     public boolean forceRefresh = false;
     private final Int2ObjectMap<Long2ObjectMap<ILocationProvider>> dimCachedLocations = new Int2ObjectOpenHashMap<>();
     private Long2ObjectMap<ILocationProvider> currentDimCache;
-    private final Set<ILocationProvider> visibleLocations = new HashSet<>();
+    private final Set<ILocationProvider> visibleLocations = new LinkedHashSet<>();
     private final Set<ILocationProvider> removeQueue = new HashSet<>();
     protected final Map<SupportedMods, LayerRenderer> layerRenderer = new EnumMap<>(SupportedMods.class);
     private int miniMapWidth = 0;
@@ -404,9 +405,10 @@ public abstract class LayerManager {
     /**
      * Queues a cached location for removal by identity.
      *
-     * @param location must be a long packed with {@link Util#packChunkToLocation(int, int)}
+     * @param location stable location identity, normally from {@link ILocationProvider#toLong()}
      */
     public final void removeLocation(long location) {
+        if (currentDimCache == null) return;
         ILocationProvider loc = currentDimCache.get(location);
         if (loc == null) return;
         removeLocation(loc);

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/layers/LayerManager.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/layers/LayerManager.java
@@ -42,6 +42,7 @@ public abstract class LayerManager {
     private boolean refreshDim = true;
     private boolean clearFull, clearCurrent;
     private boolean hasSearchField;
+    private long refreshVersion;
 
     public LayerManager(ButtonManager buttonManager) {
         this.buttonManager = buttonManager;
@@ -157,6 +158,11 @@ public abstract class LayerManager {
 
     public void forceRefresh() {
         forceRefresh = true;
+        refreshVersion++;
+    }
+
+    public long getRefreshVersion() {
+        return refreshVersion;
     }
 
     public final void onGuiOpened(SupportedMods mod) {
@@ -194,6 +200,9 @@ public abstract class LayerManager {
     }
 
     private void recacheVisibleElements(int centerBlockX, int centerBlockZ) {
+        Minecraft minecraft = Minecraft.getMinecraft();
+        if (minecraft.thePlayer == null || minecraft.theWorld == null) return;
+
         int radiusBlockX = (Math.max(miniMapWidth, fullscreenMapWidth) + 1) >> 1;
         int radiusBlockZ = (Math.max(miniMapHeight, fullscreenMapHeight) + 1) >> 1;
         int minBlockX = centerBlockX - radiusBlockX;
@@ -204,7 +213,7 @@ public abstract class LayerManager {
         if (clearCurrent) clearCurrent();
         if (clearFull) clearFull();
 
-        int dim = Minecraft.getMinecraft().thePlayer.dimension;
+        int dim = minecraft.thePlayer.dimension;
         if (refreshDim || currentDim != dim) {
             currentDim = dim;
             refreshDimCache();

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/layers/LayerRenderer.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/layers/LayerRenderer.java
@@ -68,13 +68,15 @@ public abstract class LayerRenderer {
 
         renderStep = generateRenderStep(location);
         if (renderStep != null) {
-            return currentDimSteps.put(key, renderStep);
+            currentDimSteps.put(key, renderStep);
+            return renderStep;
         }
 
         List<? extends RenderStep> renderSteps = generateRenderSteps(Collections.singletonList(location));
         if (renderSteps != null) {
             for (RenderStep step : renderSteps) {
-                return currentDimSteps.put(key, step);
+                currentDimSteps.put(key, step);
+                return step;
             }
         }
         return null;

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/layers/LayerRenderer.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/layers/LayerRenderer.java
@@ -17,6 +17,12 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 
+/**
+ * Converts a manager's cached locations into cached render steps for one map integration.
+ * <p>
+ * A render step is reused while its location identity remains cached. Override
+ * {@link #generateRenderStep(ILocationProvider)} for new implementations.
+ */
 @SuppressWarnings("DeprecatedIsStillUsed")
 public abstract class LayerRenderer {
 
@@ -27,11 +33,20 @@ public abstract class LayerRenderer {
     protected Long2ObjectMap<RenderStep> currentDimSteps;
     private final List<RenderStep> visibleSteps = new ArrayList<>();
 
+    /**
+     * @param manager owning layer manager
+     * @param mod     map integration this renderer targets, or {@link SupportedMods#NONE} for a universal renderer
+     */
     public LayerRenderer(@Nonnull LayerManager manager, SupportedMods mod) {
         this.mod = mod;
         this.manager = manager;
     }
 
+    /**
+     * Rebuilds the visible step list while reusing cached steps.
+     *
+     * @param locations currently visible locations
+     */
     public void refreshVisibleElements(Set<ILocationProvider> locations) {
         visibleSteps.clear();
         for (ILocationProvider location : locations) {
@@ -66,6 +81,8 @@ public abstract class LayerRenderer {
     }
 
     /**
+     * Creates a cached render step for one location.
+     *
      * @param location The location to generate a {@link RenderStep} for
      * @return A {@link RenderStep} for the given location, or null if none should be generated
      */
@@ -73,18 +90,22 @@ public abstract class LayerRenderer {
         return null;
     }
 
+    /** @return map integration declared by this renderer */
     public final SupportedMods getLayerMod() {
         return mod;
     }
 
+    /** @return steps in the order used for hit testing */
     public List<? extends RenderStep> getRenderStepsForInteraction() {
         return renderSteps;
     }
 
+    /** @return currently visible render steps */
     public List<? extends RenderStep> getRenderSteps() {
         return renderSteps;
     }
 
+    /** @return a new list containing visible render steps in reverse order */
     public List<? extends RenderStep> getReversedRenderSteps() {
         List<RenderStep> reversed = new ArrayList<>(renderSteps);
         Collections.reverse(reversed);
@@ -114,10 +135,18 @@ public abstract class LayerRenderer {
         dimCachedRenderSteps.clear();
     }
 
+    /**
+     * Controls ordering relative to other active layer renderers.
+     *
+     * @return ascending render priority; defaults to {@code 0}
+     */
     public int getRenderPriority() {
         return 0;
     }
 
+    /**
+     * @deprecated Visible elements are refreshed internally from {@link LayerManager}.
+     */
     @Deprecated
     public void updateVisibleElements(List<? extends ILocationProvider> visibleElements) {}
 

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/layers/LayerRenderer.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/layers/LayerRenderer.java
@@ -114,9 +114,11 @@ public abstract class LayerRenderer {
         return reversed;
     }
 
-    void removeRenderStep(long key) {
-        RenderStep renderStep = currentDimSteps.remove(key);
-        renderSteps.remove(renderStep);
+    void removeRenderStep(int dimension, long key) {
+        Long2ObjectMap<RenderStep> steps = dimCachedRenderSteps.get(dimension);
+        if (steps == null) return;
+        RenderStep removed = steps.remove(key);
+        if (steps == currentDimSteps) renderSteps.remove(removed);
     }
 
     void setDimCache(int dim) {

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/layers/UniversalInteractableRenderer.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/layers/UniversalInteractableRenderer.java
@@ -120,4 +120,17 @@ public class UniversalInteractableRenderer extends UniversalLayerRenderer implem
         return this;
     }
 
+    public boolean onRenderStepClick(UniversalInteractableStep<?> step, boolean isDoubleClick, int mouseX, int mouseY,
+        int blockX, int blockZ) {
+        hoveredRenderStep = step;
+        boolean handled = onMapClick(isDoubleClick, mouseX, mouseY, blockX, blockZ);
+        if (handled) manager.forceRefresh();
+        return handled;
+    }
+
+    public boolean onRenderStepKeyPressed(UniversalInteractableStep<?> step, int keyCode) {
+        hoveredRenderStep = step;
+        return onKeyPressed(keyCode);
+    }
+
 }

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/layers/UniversalInteractableRenderer.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/layers/UniversalInteractableRenderer.java
@@ -16,6 +16,12 @@ import com.gtnewhorizons.navigator.api.model.steps.UniversalInteractableStep;
 import com.gtnewhorizons.navigator.api.model.steps.UniversalLocationInteractableStep;
 import com.gtnewhorizons.navigator.api.util.ClickPos;
 
+/**
+ * Universal renderer that adds hover, tooltip, click, action-key, and optional waypoint behavior.
+ * <p>
+ * A configured click callback runs before the default behavior. If it does not consume a double-click, waypoint-
+ * capable locations toggle the manager's active waypoint; plain locations do nothing by default.
+ */
 public class UniversalInteractableRenderer extends UniversalLayerRenderer implements InteractableLayer {
 
     private final ClickPos clickPos = new ClickPos();
@@ -25,6 +31,7 @@ public class UniversalInteractableRenderer extends UniversalLayerRenderer implem
     private Predicate<ClickPos> clickAction;
     private IntPredicate keyPressAction;
 
+    /** @param manager owning interactable layer manager */
     public UniversalInteractableRenderer(@Nonnull InteractableLayerManager manager) {
         super(manager);
         this.manager = manager;
@@ -59,6 +66,11 @@ public class UniversalInteractableRenderer extends UniversalLayerRenderer implem
         return onClickOutsideRenderStep(isDoubleClick, mouseX, mouseY, blockX, blockZ);
     }
 
+    /**
+     * Handles a click on the currently hovered step using default waypoint behavior.
+     *
+     * @return {@code true} when a waypoint was set or cleared
+     */
     public boolean onClick(boolean isDoubleClick, int mouseX, int mouseY, int blockX, int blockZ) {
         if (isDoubleClick
             && hoveredLocationRenderStep.getLocation() instanceof IWaypointAndLocationProvider waypointLocation) {
@@ -72,6 +84,11 @@ public class UniversalInteractableRenderer extends UniversalLayerRenderer implem
         return false;
     }
 
+    /**
+     * Hook for clicks that do not target a render step.
+     *
+     * @return {@code true} when consumed
+     */
     public boolean onClickOutsideRenderStep(boolean isDoubleClick, int mouseX, int mouseY, int blockX, int blockZ) {
         return false;
     }
@@ -113,16 +130,35 @@ public class UniversalInteractableRenderer extends UniversalLayerRenderer implem
         return false;
     }
 
+    /**
+     * Installs a callback that runs before default step/outside click behavior.
+     * <p>
+     * The supplied {@link ClickPos} is mutable and reused; do not retain it.
+     *
+     * @param action callback returning {@code true} when it consumes a click
+     * @return this renderer
+     */
     public UniversalInteractableRenderer withClickAction(@Nonnull Predicate<ClickPos> action) {
         this.clickAction = action;
         return this;
     }
 
+    /**
+     * Installs a callback that runs before the hovered step's action-key handler.
+     *
+     * @param keyPressAction callback returning {@code true} when it consumes a key
+     * @return this renderer
+     */
     public UniversalInteractableRenderer withKeyPressAction(@Nonnull IntPredicate keyPressAction) {
         this.keyPressAction = keyPressAction;
         return this;
     }
 
+    /**
+     * Dispatches a click from a native overlay associated with a known step.
+     *
+     * @return whether the click was consumed
+     */
     public boolean onRenderStepClick(UniversalLocationInteractableStep<?> step, boolean isDoubleClick, int mouseX,
         int mouseY, int blockX, int blockZ) {
         setHoveredRenderStep(step);
@@ -131,15 +167,22 @@ public class UniversalInteractableRenderer extends UniversalLayerRenderer implem
         return handled;
     }
 
+    /**
+     * Dispatches a key from a native overlay associated with a known step.
+     *
+     * @return whether the key was consumed
+     */
     public boolean onRenderStepKeyPressed(UniversalLocationInteractableStep<?> step, int keyCode) {
         setHoveredRenderStep(step);
         return onKeyPressed(keyCode);
     }
 
+    /** Clears native-overlay hover only if it still points at {@code step}. */
     public void clearRenderStepHover(UniversalLocationInteractableStep<?> step) {
         if (hoveredLocationRenderStep == step) setHoveredRenderStep(null);
     }
 
+    /** Clears all cached hover state. */
     public void clearRenderStepHover() {
         setHoveredRenderStep(null);
     }

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/layers/UniversalInteractableRenderer.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/layers/UniversalInteractableRenderer.java
@@ -6,11 +6,14 @@ import java.util.function.IntPredicate;
 import java.util.function.Predicate;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import net.minecraft.client.gui.FontRenderer;
 
+import com.gtnewhorizons.navigator.api.model.locations.IWaypointAndLocationProvider;
 import com.gtnewhorizons.navigator.api.model.steps.RenderStep;
 import com.gtnewhorizons.navigator.api.model.steps.UniversalInteractableStep;
+import com.gtnewhorizons.navigator.api.model.steps.UniversalLocationInteractableStep;
 import com.gtnewhorizons.navigator.api.util.ClickPos;
 
 public class UniversalInteractableRenderer extends UniversalLayerRenderer implements InteractableLayer {
@@ -18,6 +21,7 @@ public class UniversalInteractableRenderer extends UniversalLayerRenderer implem
     private final ClickPos clickPos = new ClickPos();
     protected InteractableLayerManager manager;
     protected UniversalInteractableStep<?> hoveredRenderStep = null;
+    private UniversalLocationInteractableStep<?> hoveredLocationRenderStep = null;
     private Predicate<ClickPos> clickAction;
     private IntPredicate keyPressAction;
 
@@ -28,11 +32,11 @@ public class UniversalInteractableRenderer extends UniversalLayerRenderer implem
 
     @Override
     public void onMouseMove(int mouseX, int mouseY) {
-        hoveredRenderStep = null;
+        setHoveredRenderStep(null);
         for (RenderStep drawStep : getRenderStepsForInteraction()) {
-            if (drawStep instanceof UniversalInteractableStep<?>step) {
+            if (drawStep instanceof UniversalLocationInteractableStep<?>step) {
                 if (step.mouseOver(mouseX, mouseY)) {
-                    hoveredRenderStep = step;
+                    setHoveredRenderStep(step);
                     return;
                 }
             }
@@ -42,12 +46,13 @@ public class UniversalInteractableRenderer extends UniversalLayerRenderer implem
     @Override
     public final boolean onMapClick(boolean isDoubleClick, int mouseX, int mouseY, int blockX, int blockZ) {
         if (clickAction != null) {
-            if (clickAction.test(clickPos.set(hoveredRenderStep, isDoubleClick, mouseX, mouseY, blockX, blockZ))) {
+            if (clickAction
+                .test(clickPos.set(hoveredLocationRenderStep, isDoubleClick, mouseX, mouseY, blockX, blockZ))) {
                 return true;
             }
         }
 
-        if (hoveredRenderStep != null) {
+        if (hoveredLocationRenderStep != null) {
             return onClick(isDoubleClick, mouseX, mouseY, blockX, blockZ);
         }
 
@@ -55,14 +60,12 @@ public class UniversalInteractableRenderer extends UniversalLayerRenderer implem
     }
 
     public boolean onClick(boolean isDoubleClick, int mouseX, int mouseY, int blockX, int blockZ) {
-        if (isDoubleClick) {
-            if (hoveredRenderStep.getLocation()
-                .isActiveAsWaypoint()) {
+        if (isDoubleClick
+            && hoveredLocationRenderStep.getLocation() instanceof IWaypointAndLocationProvider waypointLocation) {
+            if (waypointLocation.isActiveAsWaypoint()) {
                 manager.clearActiveWaypoint();
             } else {
-                manager.setActiveWaypoint(
-                    hoveredRenderStep.getLocation()
-                        .toWaypoint());
+                manager.setActiveWaypoint(waypointLocation.toWaypoint());
             }
             return true;
         }
@@ -76,8 +79,8 @@ public class UniversalInteractableRenderer extends UniversalLayerRenderer implem
     @Override
     public List<String> getTooltip() {
         List<String> tooltip = new ArrayList<>();
-        if (hoveredRenderStep != null) {
-            hoveredRenderStep.getTooltip(tooltip);
+        if (hoveredLocationRenderStep != null) {
+            hoveredLocationRenderStep.getTooltip(tooltip);
         }
         return tooltip;
     }
@@ -85,8 +88,8 @@ public class UniversalInteractableRenderer extends UniversalLayerRenderer implem
     @Override
     public void drawCustomTooltip(FontRenderer fontRenderer, int mouseX, int mouseY, int displayWidth,
         int displayHeight) {
-        if (hoveredRenderStep != null) {
-            hoveredRenderStep.drawCustomTooltip(fontRenderer, mouseX, mouseY, displayWidth, displayHeight);
+        if (hoveredLocationRenderStep != null) {
+            hoveredLocationRenderStep.drawCustomTooltip(fontRenderer, mouseX, mouseY, displayWidth, displayHeight);
         }
     }
 
@@ -102,7 +105,7 @@ public class UniversalInteractableRenderer extends UniversalLayerRenderer implem
             }
         }
 
-        if (hoveredRenderStep != null && hoveredRenderStep.onKeyPressed(keyCode)) {
+        if (hoveredLocationRenderStep != null && hoveredLocationRenderStep.onKeyPressed(keyCode)) {
             manager.forceRefresh();
             return true;
         }
@@ -120,17 +123,30 @@ public class UniversalInteractableRenderer extends UniversalLayerRenderer implem
         return this;
     }
 
-    public boolean onRenderStepClick(UniversalInteractableStep<?> step, boolean isDoubleClick, int mouseX, int mouseY,
-        int blockX, int blockZ) {
-        hoveredRenderStep = step;
+    public boolean onRenderStepClick(UniversalLocationInteractableStep<?> step, boolean isDoubleClick, int mouseX,
+        int mouseY, int blockX, int blockZ) {
+        setHoveredRenderStep(step);
         boolean handled = onMapClick(isDoubleClick, mouseX, mouseY, blockX, blockZ);
         if (handled) manager.forceRefresh();
         return handled;
     }
 
-    public boolean onRenderStepKeyPressed(UniversalInteractableStep<?> step, int keyCode) {
-        hoveredRenderStep = step;
+    public boolean onRenderStepKeyPressed(UniversalLocationInteractableStep<?> step, int keyCode) {
+        setHoveredRenderStep(step);
         return onKeyPressed(keyCode);
+    }
+
+    public void clearRenderStepHover(UniversalLocationInteractableStep<?> step) {
+        if (hoveredLocationRenderStep == step) setHoveredRenderStep(null);
+    }
+
+    public void clearRenderStepHover() {
+        setHoveredRenderStep(null);
+    }
+
+    private void setHoveredRenderStep(@Nullable UniversalLocationInteractableStep<?> step) {
+        hoveredLocationRenderStep = step;
+        hoveredRenderStep = step instanceof UniversalInteractableStep<?>waypointStep ? waypointStep : null;
     }
 
 }

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/layers/UniversalInteractableRenderer.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/layers/UniversalInteractableRenderer.java
@@ -177,6 +177,11 @@ public class UniversalInteractableRenderer extends UniversalLayerRenderer implem
         return onKeyPressed(keyCode);
     }
 
+    /** Sets native-overlay hover to the associated render step. */
+    public void setRenderStepHover(UniversalLocationInteractableStep<?> step) {
+        setHoveredRenderStep(step);
+    }
+
     /** Clears native-overlay hover only if it still points at {@code step}. */
     public void clearRenderStepHover(UniversalLocationInteractableStep<?> step) {
         if (hoveredLocationRenderStep == step) setHoveredRenderStep(null);

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/layers/UniversalLayerRenderer.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/layers/UniversalLayerRenderer.java
@@ -1,5 +1,6 @@
 package com.gtnewhorizons.navigator.api.model.layers;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
 
@@ -8,12 +9,15 @@ import javax.annotation.Nullable;
 
 import com.gtnewhorizons.navigator.api.model.SupportedMods;
 import com.gtnewhorizons.navigator.api.model.locations.ILocationProvider;
+import com.gtnewhorizons.navigator.api.model.markers.MapMarker;
 import com.gtnewhorizons.navigator.api.model.steps.RenderStep;
 import com.gtnewhorizons.navigator.api.model.steps.UniversalRenderStep;
 
 public class UniversalLayerRenderer extends LayerRenderer {
 
     private Function<ILocationProvider, UniversalRenderStep<?>> stepCreator;
+    private Function<ILocationProvider, MapMarker> markerCreator;
+    private Function<ILocationProvider, Collection<?>> journeyMapV6OverlayCreator;
     private int renderPriority = 0;
 
     public UniversalLayerRenderer(@Nonnull LayerManager manager) {
@@ -29,6 +33,36 @@ public class UniversalLayerRenderer extends LayerRenderer {
     public UniversalLayerRenderer withRenderPriority(int renderPriority) {
         this.renderPriority = renderPriority;
         return this;
+    }
+
+    public UniversalLayerRenderer withMapMarker(@Nonnull Function<ILocationProvider, MapMarker> creator) {
+        markerCreator = creator;
+        return this;
+    }
+
+    public boolean hasMapMarker() {
+        return markerCreator != null;
+    }
+
+    public MapMarker createMapMarker(ILocationProvider location) {
+        return markerCreator.apply(location);
+    }
+
+    /**
+     * Adds native JourneyMap 6 displayables without making its optional API a runtime dependency of Navigator's API.
+     */
+    public UniversalLayerRenderer withJourneyMapV6Overlays(
+        @Nonnull Function<ILocationProvider, Collection<?>> creator) {
+        journeyMapV6OverlayCreator = creator;
+        return this;
+    }
+
+    public boolean hasJourneyMapV6Overlays() {
+        return markerCreator != null || journeyMapV6OverlayCreator != null;
+    }
+
+    public Collection<?> createJourneyMapV6Overlays(ILocationProvider location) {
+        return journeyMapV6OverlayCreator.apply(location);
     }
 
     @Nullable

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/layers/UniversalLayerRenderer.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/layers/UniversalLayerRenderer.java
@@ -13,6 +13,12 @@ import com.gtnewhorizons.navigator.api.model.markers.MapMarker;
 import com.gtnewhorizons.navigator.api.model.steps.RenderStep;
 import com.gtnewhorizons.navigator.api.model.steps.UniversalRenderStep;
 
+/**
+ * Map-neutral renderer configured with functions instead of one renderer subclass per map mod.
+ * <p>
+ * A universal render step is the lifecycle anchor for all output, including JourneyMap 6 native markers and raw
+ * displayables. Configure {@link #withRenderStep(Function)} even when native output replaces fullscreen drawing.
+ */
 public class UniversalLayerRenderer extends LayerRenderer {
 
     private Function<ILocationProvider, UniversalRenderStep<?>> stepCreator;
@@ -21,36 +27,64 @@ public class UniversalLayerRenderer extends LayerRenderer {
     private boolean journeyMapV6OverlaysReplaceRenderSteps;
     private int renderPriority = 0;
 
+    /** @param manager owning layer manager */
     public UniversalLayerRenderer(@Nonnull LayerManager manager) {
         super(manager, SupportedMods.NONE);
     }
 
+    /**
+     * Configures the render-step factory used for every cached visible location.
+     *
+     * @param supplier factory returning a map-neutral step
+     * @return this renderer
+     */
     public UniversalLayerRenderer withRenderStep(
         @Nonnull Function<ILocationProvider, UniversalRenderStep<?>> supplier) {
         this.stepCreator = supplier;
         return this;
     }
 
+    /**
+     * @param renderPriority ascending render/display order relative to other Navigator layers
+     * @return this renderer
+     */
     public UniversalLayerRenderer withRenderPriority(int renderPriority) {
         this.renderPriority = renderPriority;
         return this;
     }
 
+    /**
+     * Configures map-neutral JourneyMap 6 point markers.
+     * <p>
+     * Navigator owns marker context, dimension, interaction, and lifecycle. Other map integrations continue drawing
+     * the configured universal render step.
+     *
+     * @param creator marker factory; returning {@code null} hides the marker for that location
+     * @return this renderer
+     */
     public UniversalLayerRenderer withMapMarker(@Nonnull Function<ILocationProvider, MapMarker> creator) {
         markerCreator = creator;
         return this;
     }
 
+    /** @return whether a map-marker factory is configured */
     public boolean hasMapMarker() {
         return markerCreator != null;
     }
 
+    /**
+     * @param location source location
+     * @return marker description, or {@code null}
+     */
     public MapMarker createMapMarker(ILocationProvider location) {
         return markerCreator.apply(location);
     }
 
     /**
-     * Adds native JourneyMap 6 displayables without making its optional API a runtime dependency of Navigator's API.
+     * Adds native JourneyMap 6 displayables without making its optional API a runtime dependency of Navigator's
+     * common API signature.
+     * <p>
+     * The consumer must configure each displayable's dimension, UI contexts, geometry, and display properties.
      */
     public UniversalLayerRenderer withJourneyMapV6Overlays(
         @Nonnull Function<ILocationProvider, Collection<?>> creator) {
@@ -58,7 +92,11 @@ public class UniversalLayerRenderer extends LayerRenderer {
     }
 
     /**
-     * Adds native JourneyMap 6 displayables and optionally replaces this renderer's fullscreen render steps there.
+     * Adds native JourneyMap 6 displayables and optionally replaces universal fullscreen drawing on JourneyMap 6.
+     *
+     * @param creator            factory returning JourneyMap 6 {@code Displayable} instances as an untyped collection
+     * @param replaceRenderSteps whether native overlays fully replace universal fullscreen steps on JourneyMap 6
+     * @return this renderer
      */
     public UniversalLayerRenderer withJourneyMapV6Overlays(@Nonnull Function<ILocationProvider, Collection<?>> creator,
         boolean replaceRenderSteps) {
@@ -67,14 +105,20 @@ public class UniversalLayerRenderer extends LayerRenderer {
         return this;
     }
 
+    /** @return whether either a marker or raw JourneyMap 6 displayable factory is configured */
     public boolean hasJourneyMapV6Overlays() {
         return markerCreator != null || journeyMapV6OverlayCreator != null;
     }
 
+    /**
+     * @param location source location
+     * @return raw JourneyMap 6 displayable candidates, or {@code null}
+     */
     public Collection<?> createJourneyMapV6Overlays(ILocationProvider location) {
         return journeyMapV6OverlayCreator.apply(location);
     }
 
+    /** @return whether native JM6 displayables replace universal fullscreen rendering */
     public boolean journeyMapV6OverlaysReplaceRenderSteps() {
         return journeyMapV6OverlaysReplaceRenderSteps;
     }

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/layers/UniversalLayerRenderer.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/layers/UniversalLayerRenderer.java
@@ -18,6 +18,7 @@ public class UniversalLayerRenderer extends LayerRenderer {
     private Function<ILocationProvider, UniversalRenderStep<?>> stepCreator;
     private Function<ILocationProvider, MapMarker> markerCreator;
     private Function<ILocationProvider, Collection<?>> journeyMapV6OverlayCreator;
+    private boolean journeyMapV6OverlaysReplaceRenderSteps;
     private int renderPriority = 0;
 
     public UniversalLayerRenderer(@Nonnull LayerManager manager) {
@@ -53,7 +54,16 @@ public class UniversalLayerRenderer extends LayerRenderer {
      */
     public UniversalLayerRenderer withJourneyMapV6Overlays(
         @Nonnull Function<ILocationProvider, Collection<?>> creator) {
+        return withJourneyMapV6Overlays(creator, false);
+    }
+
+    /**
+     * Adds native JourneyMap 6 displayables and optionally replaces this renderer's fullscreen render steps there.
+     */
+    public UniversalLayerRenderer withJourneyMapV6Overlays(@Nonnull Function<ILocationProvider, Collection<?>> creator,
+        boolean replaceRenderSteps) {
         journeyMapV6OverlayCreator = creator;
+        journeyMapV6OverlaysReplaceRenderSteps = replaceRenderSteps;
         return this;
     }
 
@@ -63,6 +73,10 @@ public class UniversalLayerRenderer extends LayerRenderer {
 
     public Collection<?> createJourneyMapV6Overlays(ILocationProvider location) {
         return journeyMapV6OverlayCreator.apply(location);
+    }
+
+    public boolean journeyMapV6OverlaysReplaceRenderSteps() {
+        return journeyMapV6OverlaysReplaceRenderSteps;
     }
 
     @Nullable

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/layers/UniversalLayerRenderer.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/layers/UniversalLayerRenderer.java
@@ -76,8 +76,8 @@ public class UniversalLayerRenderer extends LayerRenderer {
      * @param location source location
      * @return marker description, or {@code null}
      */
-    public MapMarker createMapMarker(ILocationProvider location) {
-        return markerCreator.apply(location);
+    public @Nullable MapMarker createMapMarker(ILocationProvider location) {
+        return markerCreator == null ? null : markerCreator.apply(location);
     }
 
     /**
@@ -114,8 +114,8 @@ public class UniversalLayerRenderer extends LayerRenderer {
      * @param location source location
      * @return raw JourneyMap 6 displayable candidates, or {@code null}
      */
-    public Collection<?> createJourneyMapV6Overlays(ILocationProvider location) {
-        return journeyMapV6OverlayCreator.apply(location);
+    public @Nullable Collection<?> createJourneyMapV6Overlays(ILocationProvider location) {
+        return journeyMapV6OverlayCreator == null ? null : journeyMapV6OverlayCreator.apply(location);
     }
 
     /** @return whether native JM6 displayables replace universal fullscreen rendering */

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/locations/ILocationProvider.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/locations/ILocationProvider.java
@@ -30,12 +30,12 @@ public interface ILocationProvider {
 
     /** @return chunk X containing {@link #getBlockX()} */
     default int getChunkX() {
-        return Util.coordBlockToChunk((int) getBlockX());
+        return Util.coordBlockToChunk((int) Math.floor(getBlockX()));
     }
 
     /** @return chunk Z containing {@link #getBlockZ()} */
     default int getChunkZ() {
-        return Util.coordBlockToChunk((int) getBlockZ());
+        return Util.coordBlockToChunk((int) Math.floor(getBlockZ()));
     }
 
 }

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/locations/ILocationProvider.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/locations/ILocationProvider.java
@@ -2,22 +2,38 @@ package com.gtnewhorizons.navigator.api.model.locations;
 
 import com.gtnewhorizons.navigator.api.util.Util;
 
+/**
+ * Logical element that can be cached and shown by a Navigator layer.
+ * <p>
+ * The default identity is its packed chunk position, so it is appropriate for chunk-grid data and one element per
+ * chunk. Implementations that represent a larger element may override {@link #toLong()} with another stable key.
+ */
 public interface ILocationProvider {
 
+    /** @return dimension containing this element */
     int getDimensionId();
 
+    /** @return world block X coordinate; fractional positions are allowed */
     double getBlockX();
 
+    /** @return world block Z coordinate; fractional positions are allowed */
     double getBlockZ();
 
+    /**
+     * Returns the stable identity used by renderer caches and removal operations.
+     *
+     * @return packed chunk identity by default
+     */
     default long toLong() {
         return Util.packChunkToLocation(getChunkX(), getChunkZ());
     }
 
+    /** @return chunk X containing {@link #getBlockX()} */
     default int getChunkX() {
         return Util.coordBlockToChunk((int) getBlockX());
     }
 
+    /** @return chunk Z containing {@link #getBlockZ()} */
     default int getChunkZ() {
         return Util.coordBlockToChunk((int) getBlockZ());
     }

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/locations/IWaypointAndLocationProvider.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/locations/IWaypointAndLocationProvider.java
@@ -2,13 +2,27 @@ package com.gtnewhorizons.navigator.api.model.locations;
 
 import com.gtnewhorizons.navigator.api.model.waypoints.Waypoint;
 
+/**
+ * Optional capability for locations that can become Navigator's active waypoint.
+ * <p>
+ * Plain clickable locations should implement only {@link ILocationProvider} and use a location-neutral interactable
+ * render step. Do not return {@code null} from {@link #toWaypoint()} to emulate another double-click action.
+ */
 public interface IWaypointAndLocationProvider extends ILocationProvider {
 
+    /** @return a complete waypoint representing this location */
     Waypoint toWaypoint();
 
+    /** @return whether this location currently represents the manager's active waypoint */
     boolean isActiveAsWaypoint();
 
+    /** Called when the manager clears its active waypoint. */
     void onWaypointCleared();
 
+    /**
+     * Called when the manager sets or synchronizes an active waypoint.
+     *
+     * @param waypoint current active waypoint
+     */
     void onWaypointUpdated(Waypoint waypoint);
 }

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/markers/MapMarker.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/markers/MapMarker.java
@@ -11,6 +11,8 @@ import javax.annotation.Nullable;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.util.ResourceLocation;
 
+import com.gtnewhorizons.navigator.api.model.steps.UniversalRenderStep;
+
 /**
  * Map-neutral description of a JourneyMap 6 native point marker.
  * <p>
@@ -35,6 +37,8 @@ public final class MapMarker {
     private int labelOffsetY;
     private @Nullable Integer labelMinZoom;
     private boolean labelOnMinimap = true;
+    private @Nullable double[] displayZoomScale;
+    private @Nullable double[] labelZoomScale;
 
     /**
      * Creates a marker from an in-memory image.
@@ -104,6 +108,12 @@ public final class MapMarker {
         return this;
     }
 
+    /** Scales the icon over normalized zoom steps on JourneyMap 6's fullscreen map. */
+    public MapMarker setDisplayZoomScale(double minScale, double maxScale, double minZoom, double maxZoom) {
+        displayZoomScale = zoomScale(minScale, maxScale, minZoom, maxZoom);
+        return this;
+    }
+
     /** @return this marker */
     public MapMarker setLabel(@Nullable String label) {
         this.label = label;
@@ -131,6 +141,12 @@ public final class MapMarker {
     /** @return this marker */
     public MapMarker setLabelScale(float labelScale) {
         this.labelScale = labelScale;
+        return this;
+    }
+
+    /** Scales the label over normalized zoom steps on JourneyMap 6's fullscreen map. */
+    public MapMarker setLabelZoomScale(double minScale, double maxScale, double minZoom, double maxZoom) {
+        labelZoomScale = zoomScale(minScale, maxScale, minZoom, maxZoom);
         return this;
     }
 
@@ -208,6 +224,11 @@ public final class MapMarker {
         return displayHeight;
     }
 
+    /** @return fullscreen icon multiplier for the supplied normalized zoom step */
+    public double getDisplayZoomScale(double zoomStep) {
+        return interpolate(displayZoomScale, zoomStep);
+    }
+
     /** @return marker label, or {@code null} */
     public @Nullable String getLabel() {
         return label;
@@ -228,6 +249,11 @@ public final class MapMarker {
         return labelScale;
     }
 
+    /** @return fullscreen label multiplier for the supplied normalized zoom step */
+    public double getLabelZoomScale(double zoomStep) {
+        return interpolate(labelZoomScale, zoomStep);
+    }
+
     /** @return label background opacity */
     public float getLabelBackgroundOpacity() {
         return labelBackgroundOpacity;
@@ -246,5 +272,16 @@ public final class MapMarker {
     /** @return whether label text is enabled on the minimap */
     public boolean isLabelOnMinimap() {
         return labelOnMinimap;
+    }
+
+    private static double[] zoomScale(double minScale, double maxScale, double minZoom, double maxZoom) {
+        if (minScale <= 0 || maxScale <= 0) throw new IllegalArgumentException("zoom scales must be positive");
+        if (maxZoom <= minZoom) throw new IllegalArgumentException("maxZoom must be greater than minZoom");
+        return new double[] { minScale, maxScale, minZoom, maxZoom };
+    }
+
+    private static double interpolate(@Nullable double[] scale, double zoomStep) {
+        return scale == null ? 1
+            : UniversalRenderStep.interpolateZoomScale(zoomStep, scale[0], scale[1], scale[2], scale[3]);
     }
 }

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/markers/MapMarker.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/markers/MapMarker.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 
 import javax.annotation.Nullable;
 
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.util.ResourceLocation;
 
 /**
@@ -20,6 +21,8 @@ public final class MapMarker {
 
     private final @Nullable BufferedImage image;
     private final @Nullable ResourceLocation imageLocation;
+    private final int textureX;
+    private final int textureY;
     private final int textureWidth;
     private final int textureHeight;
     private double displayWidth;
@@ -41,6 +44,8 @@ public final class MapMarker {
     public MapMarker(BufferedImage image) {
         this.image = Objects.requireNonNull(image);
         imageLocation = null;
+        textureX = 0;
+        textureY = 0;
         textureWidth = image.getWidth();
         textureHeight = image.getHeight();
         displayWidth = textureWidth;
@@ -55,8 +60,33 @@ public final class MapMarker {
      * @param textureHeight source texture height in pixels
      */
     public MapMarker(ResourceLocation imageLocation, int textureWidth, int textureHeight) {
+        this(imageLocation, 0, 0, textureWidth, textureHeight);
+    }
+
+    /**
+     * Creates a marker from a sprite already stitched into a Minecraft texture atlas.
+     *
+     * @param atlasLocation texture atlas resource
+     * @param sprite        stitched sprite; animated atlas updates remain visible
+     */
+    public MapMarker(ResourceLocation atlasLocation, TextureAtlasSprite sprite) {
+        this(atlasLocation, sprite.getOriginX(), sprite.getOriginY(), sprite.getIconWidth(), sprite.getIconHeight());
+    }
+
+    /**
+     * Creates a marker from a region of a Minecraft texture, such as an animated block-atlas sprite.
+     *
+     * @param imageLocation texture resource
+     * @param textureX      source region X in pixels
+     * @param textureY      source region Y in pixels
+     * @param textureWidth  source region width in pixels
+     * @param textureHeight source region height in pixels
+     */
+    public MapMarker(ResourceLocation imageLocation, int textureX, int textureY, int textureWidth, int textureHeight) {
         image = null;
         this.imageLocation = Objects.requireNonNull(imageLocation);
+        this.textureX = Math.max(0, textureX);
+        this.textureY = Math.max(0, textureY);
         this.textureWidth = Math.max(1, textureWidth);
         this.textureHeight = Math.max(1, textureHeight);
         displayWidth = this.textureWidth;
@@ -146,6 +176,16 @@ public final class MapMarker {
     /** @return texture resource, or {@code null} when backed by an in-memory image */
     public @Nullable ResourceLocation getImageLocation() {
         return imageLocation;
+    }
+
+    /** @return source texture X */
+    public int getTextureX() {
+        return textureX;
+    }
+
+    /** @return source texture Y */
+    public int getTextureY() {
+        return textureY;
     }
 
     /** @return source texture width */

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/markers/MapMarker.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/markers/MapMarker.java
@@ -11,7 +11,10 @@ import javax.annotation.Nullable;
 import net.minecraft.util.ResourceLocation;
 
 /**
- * Map-neutral description of a point marker. Map integrations decide how to display it.
+ * Map-neutral description of a JourneyMap 6 native point marker.
+ * <p>
+ * Navigator creates and owns the native overlay, enables fullscreen and minimap contexts, centers image anchors, and
+ * forwards interaction. JourneyMap 5 and Xaero continue using the renderer's universal render step.
  */
 public final class MapMarker {
 
@@ -30,6 +33,11 @@ public final class MapMarker {
     private @Nullable Integer labelMinZoom;
     private boolean labelOnMinimap = true;
 
+    /**
+     * Creates a marker from an in-memory image.
+     *
+     * @param image non-null image whose pixel dimensions become the initial display size
+     */
     public MapMarker(BufferedImage image) {
         this.image = Objects.requireNonNull(image);
         imageLocation = null;
@@ -39,6 +47,13 @@ public final class MapMarker {
         displayHeight = textureHeight;
     }
 
+    /**
+     * Creates a marker from a Minecraft texture.
+     *
+     * @param imageLocation texture resource
+     * @param textureWidth  source texture width in pixels
+     * @param textureHeight source texture height in pixels
+     */
     public MapMarker(ResourceLocation imageLocation, int textureWidth, int textureHeight) {
         image = null;
         this.imageLocation = Objects.requireNonNull(imageLocation);
@@ -48,37 +63,54 @@ public final class MapMarker {
         displayHeight = this.textureHeight;
     }
 
+    /**
+     * @param width  displayed width in map pixels
+     * @param height displayed height in map pixels
+     * @return this marker
+     */
     public MapMarker setDisplaySize(double width, double height) {
         displayWidth = width;
         displayHeight = height;
         return this;
     }
 
+    /** @return this marker */
     public MapMarker setLabel(@Nullable String label) {
         this.label = label;
         return this;
     }
 
+    /**
+     * Copies tooltip lines into an immutable list.
+     * <p>
+     * When no tooltip is supplied, Navigator obtains lines from an associated interactable render step.
+     *
+     * @return this marker
+     */
     public MapMarker setTooltip(@Nullable List<String> tooltip) {
         this.tooltip = tooltip == null ? null : Collections.unmodifiableList(new ArrayList<>(tooltip));
         return this;
     }
 
+    /** @return this marker */
     public MapMarker setLabelColor(int labelColor) {
         this.labelColor = labelColor;
         return this;
     }
 
+    /** @return this marker */
     public MapMarker setLabelScale(float labelScale) {
         this.labelScale = labelScale;
         return this;
     }
 
+    /** @return this marker */
     public MapMarker setLabelBackgroundOpacity(float labelBackgroundOpacity) {
         this.labelBackgroundOpacity = labelBackgroundOpacity;
         return this;
     }
 
+    /** @return this marker */
     public MapMarker setLabelOffsetY(int labelOffsetY) {
         this.labelOffsetY = labelOffsetY;
         return this;
@@ -86,69 +118,92 @@ public final class MapMarker {
 
     /**
      * Sets the minimum Navigator zoom step where the label is visible.
+     *
+     * @param labelMinZoom normalized Navigator zoom step
+     * @return this marker
      */
     public MapMarker setLabelMinZoom(int labelMinZoom) {
         this.labelMinZoom = labelMinZoom;
         return this;
     }
 
+    /**
+     * Controls only the label context; the icon remains enabled on the minimap.
+     *
+     * @param labelOnMinimap whether marker text is visible on the minimap
+     * @return this marker
+     */
     public MapMarker setLabelOnMinimap(boolean labelOnMinimap) {
         this.labelOnMinimap = labelOnMinimap;
         return this;
     }
 
+    /** @return in-memory image, or {@code null} when backed by a resource */
     public @Nullable BufferedImage getImage() {
         return image;
     }
 
+    /** @return texture resource, or {@code null} when backed by an in-memory image */
     public @Nullable ResourceLocation getImageLocation() {
         return imageLocation;
     }
 
+    /** @return source texture width */
     public int getTextureWidth() {
         return textureWidth;
     }
 
+    /** @return source texture height */
     public int getTextureHeight() {
         return textureHeight;
     }
 
+    /** @return displayed marker width */
     public double getDisplayWidth() {
         return displayWidth;
     }
 
+    /** @return displayed marker height */
     public double getDisplayHeight() {
         return displayHeight;
     }
 
+    /** @return marker label, or {@code null} */
     public @Nullable String getLabel() {
         return label;
     }
 
+    /** @return immutable tooltip lines, or {@code null} to use the render step tooltip */
     public @Nullable List<String> getTooltip() {
         return tooltip;
     }
 
+    /** @return RGB label color */
     public int getLabelColor() {
         return labelColor;
     }
 
+    /** @return label scale multiplier */
     public float getLabelScale() {
         return labelScale;
     }
 
+    /** @return label background opacity */
     public float getLabelBackgroundOpacity() {
         return labelBackgroundOpacity;
     }
 
+    /** @return label Y offset */
     public int getLabelOffsetY() {
         return labelOffsetY;
     }
 
+    /** @return minimum normalized zoom step, or {@code null} for JourneyMap's default */
     public @Nullable Integer getLabelMinZoom() {
         return labelMinZoom;
     }
 
+    /** @return whether label text is enabled on the minimap */
     public boolean isLabelOnMinimap() {
         return labelOnMinimap;
     }

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/markers/MapMarker.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/markers/MapMarker.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
@@ -19,6 +20,7 @@ import com.gtnewhorizons.navigator.api.model.steps.UniversalRenderStep;
  * Navigator creates and owns the native overlay, enables fullscreen and minimap contexts, centers image anchors, and
  * forwards interaction. JourneyMap 5 and Xaero continue using the renderer's universal render step.
  */
+@SuppressWarnings("unused")
 public final class MapMarker {
 
     private final @Nullable BufferedImage image;
@@ -30,6 +32,7 @@ public final class MapMarker {
     private double displayWidth;
     private double displayHeight;
     private @Nullable String label;
+    private @Nullable Supplier<String> labelSupplier;
     private @Nullable List<String> tooltip;
     private int labelColor = 0xFFFFFF;
     private float labelScale = 1.0F;
@@ -117,6 +120,18 @@ public final class MapMarker {
     /** @return this marker */
     public MapMarker setLabel(@Nullable String label) {
         this.label = label;
+        labelSupplier = null;
+        return this;
+    }
+
+    /**
+     * Supplies label text that JourneyMap 6 checks once per second without recreating the marker.
+     *
+     * @param labelSupplier dynamic label supplier
+     * @return this marker
+     */
+    public MapMarker setLabelSupplier(Supplier<String> labelSupplier) {
+        this.labelSupplier = Objects.requireNonNull(labelSupplier);
         return this;
     }
 
@@ -231,7 +246,12 @@ public final class MapMarker {
 
     /** @return marker label, or {@code null} */
     public @Nullable String getLabel() {
-        return label;
+        return labelSupplier == null ? label : labelSupplier.get();
+    }
+
+    /** @return whether this marker's label can change without rebuilding the marker */
+    public boolean hasDynamicLabel() {
+        return labelSupplier != null;
     }
 
     /** @return immutable tooltip lines, or {@code null} to use the render step tooltip */

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/markers/MapMarker.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/markers/MapMarker.java
@@ -1,0 +1,155 @@
+package com.gtnewhorizons.navigator.api.model.markers;
+
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.util.ResourceLocation;
+
+/**
+ * Map-neutral description of a point marker. Map integrations decide how to display it.
+ */
+public final class MapMarker {
+
+    private final @Nullable BufferedImage image;
+    private final @Nullable ResourceLocation imageLocation;
+    private final int textureWidth;
+    private final int textureHeight;
+    private double displayWidth;
+    private double displayHeight;
+    private @Nullable String label;
+    private @Nullable List<String> tooltip;
+    private int labelColor = 0xFFFFFF;
+    private float labelScale = 1.0F;
+    private float labelBackgroundOpacity;
+    private int labelOffsetY;
+    private @Nullable Integer labelMinZoom;
+    private boolean labelOnMinimap = true;
+
+    public MapMarker(BufferedImage image) {
+        this.image = Objects.requireNonNull(image);
+        imageLocation = null;
+        textureWidth = image.getWidth();
+        textureHeight = image.getHeight();
+        displayWidth = textureWidth;
+        displayHeight = textureHeight;
+    }
+
+    public MapMarker(ResourceLocation imageLocation, int textureWidth, int textureHeight) {
+        image = null;
+        this.imageLocation = Objects.requireNonNull(imageLocation);
+        this.textureWidth = Math.max(1, textureWidth);
+        this.textureHeight = Math.max(1, textureHeight);
+        displayWidth = this.textureWidth;
+        displayHeight = this.textureHeight;
+    }
+
+    public MapMarker setDisplaySize(double width, double height) {
+        displayWidth = width;
+        displayHeight = height;
+        return this;
+    }
+
+    public MapMarker setLabel(@Nullable String label) {
+        this.label = label;
+        return this;
+    }
+
+    public MapMarker setTooltip(@Nullable List<String> tooltip) {
+        this.tooltip = tooltip == null ? null : Collections.unmodifiableList(new ArrayList<>(tooltip));
+        return this;
+    }
+
+    public MapMarker setLabelColor(int labelColor) {
+        this.labelColor = labelColor;
+        return this;
+    }
+
+    public MapMarker setLabelScale(float labelScale) {
+        this.labelScale = labelScale;
+        return this;
+    }
+
+    public MapMarker setLabelBackgroundOpacity(float labelBackgroundOpacity) {
+        this.labelBackgroundOpacity = labelBackgroundOpacity;
+        return this;
+    }
+
+    public MapMarker setLabelOffsetY(int labelOffsetY) {
+        this.labelOffsetY = labelOffsetY;
+        return this;
+    }
+
+    /**
+     * Sets the minimum Navigator zoom step where the label is visible.
+     */
+    public MapMarker setLabelMinZoom(int labelMinZoom) {
+        this.labelMinZoom = labelMinZoom;
+        return this;
+    }
+
+    public MapMarker setLabelOnMinimap(boolean labelOnMinimap) {
+        this.labelOnMinimap = labelOnMinimap;
+        return this;
+    }
+
+    public @Nullable BufferedImage getImage() {
+        return image;
+    }
+
+    public @Nullable ResourceLocation getImageLocation() {
+        return imageLocation;
+    }
+
+    public int getTextureWidth() {
+        return textureWidth;
+    }
+
+    public int getTextureHeight() {
+        return textureHeight;
+    }
+
+    public double getDisplayWidth() {
+        return displayWidth;
+    }
+
+    public double getDisplayHeight() {
+        return displayHeight;
+    }
+
+    public @Nullable String getLabel() {
+        return label;
+    }
+
+    public @Nullable List<String> getTooltip() {
+        return tooltip;
+    }
+
+    public int getLabelColor() {
+        return labelColor;
+    }
+
+    public float getLabelScale() {
+        return labelScale;
+    }
+
+    public float getLabelBackgroundOpacity() {
+        return labelBackgroundOpacity;
+    }
+
+    public int getLabelOffsetY() {
+        return labelOffsetY;
+    }
+
+    public @Nullable Integer getLabelMinZoom() {
+        return labelMinZoom;
+    }
+
+    public boolean isLabelOnMinimap() {
+        return labelOnMinimap;
+    }
+}

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/steps/InteractableStep.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/steps/InteractableStep.java
@@ -6,6 +6,12 @@ import com.gtnewhorizons.navigator.api.NavigatorApi;
 import com.gtnewhorizons.navigator.api.model.locations.IWaypointAndLocationProvider;
 import com.gtnewhorizons.navigator.api.util.Util;
 
+/**
+ * Legacy interaction contract whose location is always waypoint-capable.
+ * <p>
+ * New non-waypoint layers should use {@link LocationInteractableStep}. This interface remains for source and binary
+ * compatibility and for layers that intentionally use the default double-click waypoint behavior.
+ */
 public interface InteractableStep extends LocationInteractableStep {
 
     void getTooltip(List<String> list);
@@ -26,6 +32,8 @@ public interface InteractableStep extends LocationInteractableStep {
     }
 
     /**
+     * Legacy location accessor retained for old implementations.
+     *
      * @deprecated Use {@link #getLocation()} instead
      */
     @Deprecated

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/steps/LocationInteractableStep.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/steps/LocationInteractableStep.java
@@ -3,10 +3,9 @@ package com.gtnewhorizons.navigator.api.model.steps;
 import java.util.List;
 
 import com.gtnewhorizons.navigator.api.NavigatorApi;
-import com.gtnewhorizons.navigator.api.model.locations.IWaypointAndLocationProvider;
 import com.gtnewhorizons.navigator.api.util.Util;
 
-public interface InteractableStep extends LocationInteractableStep {
+public interface LocationInteractableStep extends RenderStep {
 
     void getTooltip(List<String> list);
 
@@ -18,18 +17,5 @@ public interface InteractableStep extends LocationInteractableStep {
             return true;
         }
         return false;
-    }
-
-    @Override
-    default IWaypointAndLocationProvider getLocation() {
-        return getLocationProvider();
-    }
-
-    /**
-     * @deprecated Use {@link #getLocation()} instead
-     */
-    @Deprecated
-    default IWaypointAndLocationProvider getLocationProvider() {
-        return null;
     }
 }

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/steps/LocationInteractableStep.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/steps/LocationInteractableStep.java
@@ -5,12 +5,29 @@ import java.util.List;
 import com.gtnewhorizons.navigator.api.NavigatorApi;
 import com.gtnewhorizons.navigator.api.util.Util;
 
+/**
+ * Interaction contract for any {@link com.gtnewhorizons.navigator.api.model.locations.ILocationProvider}.
+ * <p>
+ * This is the location-neutral alternative to the legacy waypoint-bound {@link InteractableStep}.
+ */
 public interface LocationInteractableStep extends RenderStep {
 
+    /**
+     * Appends tooltip lines for this step.
+     *
+     * @param list mutable tooltip supplied by Navigator
+     */
     void getTooltip(List<String> list);
 
+    /** Called when Navigator's shared action key is pressed while this step is hovered. */
     void onActionKeyPressed();
 
+    /**
+     * Handles a raw key press. The default implementation dispatches {@link NavigatorApi#ACTION_KEY}.
+     *
+     * @param keyCode LWJGL key code
+     * @return {@code true} when the key was consumed
+     */
     default boolean onKeyPressed(int keyCode) {
         if (Util.isKeyPressed(NavigatorApi.ACTION_KEY)) {
             onActionKeyPressed();

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/steps/RenderStep.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/steps/RenderStep.java
@@ -2,8 +2,12 @@ package com.gtnewhorizons.navigator.api.model.steps;
 
 import com.gtnewhorizons.navigator.api.model.locations.ILocationProvider;
 
+/** Visual representation derived from one cached {@link ILocationProvider}. */
 public interface RenderStep {
 
+    /**
+     * @return source location, or {@code null} for legacy implementations that do not expose one
+     */
     default ILocationProvider getLocation() {
         return null;
     }

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/steps/UniversalInteractableStep.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/steps/UniversalInteractableStep.java
@@ -3,6 +3,15 @@ package com.gtnewhorizons.navigator.api.model.steps;
 import com.gtnewhorizons.navigator.api.model.locations.IWaypointAndLocationProvider;
 import com.gtnewhorizons.navigator.api.xaero.rendersteps.XaeroInteractableStep;
 
+/**
+ * Universal interactable step for locations that support Navigator waypoints.
+ * <p>
+ * {@link com.gtnewhorizons.navigator.api.model.layers.UniversalInteractableRenderer} supplies default double-click
+ * set/clear waypoint behavior for this step. Use {@link UniversalLocationInteractableStep} for domain interaction
+ * without waypoints.
+ *
+ * @param <T> waypoint-capable location type
+ */
 public abstract class UniversalInteractableStep<T extends IWaypointAndLocationProvider>
     extends UniversalLocationInteractableStep<T> implements XaeroInteractableStep {
 

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/steps/UniversalInteractableStep.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/steps/UniversalInteractableStep.java
@@ -3,17 +3,11 @@ package com.gtnewhorizons.navigator.api.model.steps;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiScreen;
 
-import com.gtnewhorizons.navigator.api.journeymap.drawsteps.JMInteractableStep;
 import com.gtnewhorizons.navigator.api.model.locations.IWaypointAndLocationProvider;
 import com.gtnewhorizons.navigator.api.xaero.rendersteps.XaeroInteractableStep;
 
-import cpw.mods.fml.common.Optional;
-
-@Optional.Interface(
-    iface = "com.gtnewhorizons.navigator.api.journeymap.drawsteps.JMInteractableStep",
-    modid = "journeymap")
 public abstract class UniversalInteractableStep<T extends IWaypointAndLocationProvider> extends UniversalRenderStep<T>
-    implements JMInteractableStep, XaeroInteractableStep {
+    implements XaeroInteractableStep {
 
     public UniversalInteractableStep(T location) {
         super(location);
@@ -21,11 +15,9 @@ public abstract class UniversalInteractableStep<T extends IWaypointAndLocationPr
 
     public abstract void draw(double x, double y, float drawScale, double zoom);
 
-    @Override
     public void drawCustomTooltip(FontRenderer fontRenderer, int mouseX, int mouseY, int displayWidth,
         int displayHeight) {}
 
-    @Override
     public boolean isMouseOver(int mouseX, int mouseY) {
         return mouseX >= getX() && mouseX <= getX() + getAdjustedWidth()
             && mouseY >= getY()

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/steps/UniversalInteractableStep.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/steps/UniversalInteractableStep.java
@@ -1,49 +1,12 @@
 package com.gtnewhorizons.navigator.api.model.steps;
 
-import net.minecraft.client.gui.FontRenderer;
-import net.minecraft.client.gui.GuiScreen;
-
 import com.gtnewhorizons.navigator.api.model.locations.IWaypointAndLocationProvider;
 import com.gtnewhorizons.navigator.api.xaero.rendersteps.XaeroInteractableStep;
 
-public abstract class UniversalInteractableStep<T extends IWaypointAndLocationProvider> extends UniversalRenderStep<T>
-    implements XaeroInteractableStep {
+public abstract class UniversalInteractableStep<T extends IWaypointAndLocationProvider>
+    extends UniversalLocationInteractableStep<T> implements XaeroInteractableStep {
 
     public UniversalInteractableStep(T location) {
         super(location);
     }
-
-    public abstract void draw(double x, double y, float drawScale, double zoom);
-
-    public void drawCustomTooltip(FontRenderer fontRenderer, int mouseX, int mouseY, int displayWidth,
-        int displayHeight) {}
-
-    public boolean isMouseOver(int mouseX, int mouseY) {
-        return mouseX >= getX() && mouseX <= getX() + getAdjustedWidth()
-            && mouseY >= getY()
-            && mouseY <= getY() + getAdjustedHeight();
-    }
-
-    public final boolean mouseOver(int mouseX, int mouseY) {
-        if (isXaero && shouldScale) {
-            mouseX = (int) (mouseX * getScaling(zoom));
-            mouseY = (int) (mouseY * getScaling(zoom));
-        }
-
-        return isMouseOver(mouseX, mouseY);
-
-    }
-
-    @Override
-    public final boolean isMouseOver(double mouseX, double mouseY, double scale) {
-        return false;
-    }
-
-    @Override
-    public final void drawCustomTooltip(GuiScreen gui, double mouseX, double mouseY, double scale, int scaleAdj) {
-        drawCustomTooltip(gui.mc.fontRenderer, (int) mouseX, (int) mouseY, gui.width, gui.height);
-    }
-
-    @Override
-    public void onActionKeyPressed() {}
 }

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/steps/UniversalLocationInteractableStep.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/steps/UniversalLocationInteractableStep.java
@@ -5,6 +5,14 @@ import net.minecraft.client.gui.GuiScreen;
 
 import com.gtnewhorizons.navigator.api.model.locations.ILocationProvider;
 
+/**
+ * Universal interactable step for a plain location with no waypoint requirement.
+ * <p>
+ * Subclasses normally provide tooltip lines, optional action-key behavior, and may override the rectangular
+ * {@link #isMouseOver(int, int)} hit test.
+ *
+ * @param <T> source location type
+ */
 public abstract class UniversalLocationInteractableStep<T extends ILocationProvider> extends UniversalRenderStep<T>
     implements LocationInteractableStep {
 
@@ -14,15 +22,36 @@ public abstract class UniversalLocationInteractableStep<T extends ILocationProvi
 
     public abstract void draw(double x, double y, float drawScale, double zoom);
 
+    /**
+     * Draws a custom tooltip after normal tooltip processing.
+     *
+     * @param fontRenderer  Minecraft font renderer
+     * @param mouseX        mouse X in GUI coordinates
+     * @param mouseY        mouse Y in GUI coordinates
+     * @param displayWidth  GUI width
+     * @param displayHeight GUI height
+     */
     public void drawCustomTooltip(FontRenderer fontRenderer, int mouseX, int mouseY, int displayWidth,
         int displayHeight) {}
 
+    /**
+     * Tests the default rectangular hit area.
+     *
+     * @param mouseX mouse X in the current map's interaction coordinates
+     * @param mouseY mouse Y in the current map's interaction coordinates
+     * @return whether the pointer is inside this step
+     */
     public boolean isMouseOver(int mouseX, int mouseY) {
         return mouseX >= getX() && mouseX <= getX() + getAdjustedWidth()
             && mouseY >= getY()
             && mouseY <= getY() + getAdjustedHeight();
     }
 
+    /**
+     * Applies integration-specific scaling before calling {@link #isMouseOver(int, int)}.
+     *
+     * @return whether the pointer is inside this step
+     */
     public final boolean mouseOver(int mouseX, int mouseY) {
         if (isXaero && shouldScale) {
             mouseX = (int) (mouseX * getScaling(zoom));
@@ -40,6 +69,7 @@ public abstract class UniversalLocationInteractableStep<T extends ILocationProvi
         drawCustomTooltip(gui.mc.fontRenderer, (int) mouseX, (int) mouseY, gui.width, gui.height);
     }
 
+    /** Default action-key hook; subclasses may override. */
     @Override
     public void onActionKeyPressed() {}
 }

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/steps/UniversalLocationInteractableStep.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/steps/UniversalLocationInteractableStep.java
@@ -1,0 +1,45 @@
+package com.gtnewhorizons.navigator.api.model.steps;
+
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.gui.GuiScreen;
+
+import com.gtnewhorizons.navigator.api.model.locations.ILocationProvider;
+
+public abstract class UniversalLocationInteractableStep<T extends ILocationProvider> extends UniversalRenderStep<T>
+    implements LocationInteractableStep {
+
+    public UniversalLocationInteractableStep(T location) {
+        super(location);
+    }
+
+    public abstract void draw(double x, double y, float drawScale, double zoom);
+
+    public void drawCustomTooltip(FontRenderer fontRenderer, int mouseX, int mouseY, int displayWidth,
+        int displayHeight) {}
+
+    public boolean isMouseOver(int mouseX, int mouseY) {
+        return mouseX >= getX() && mouseX <= getX() + getAdjustedWidth()
+            && mouseY >= getY()
+            && mouseY <= getY() + getAdjustedHeight();
+    }
+
+    public final boolean mouseOver(int mouseX, int mouseY) {
+        if (isXaero && shouldScale) {
+            mouseX = (int) (mouseX * getScaling(zoom));
+            mouseY = (int) (mouseY * getScaling(zoom));
+        }
+
+        return isMouseOver(mouseX, mouseY);
+    }
+
+    public final boolean isMouseOver(double mouseX, double mouseY, double scale) {
+        return false;
+    }
+
+    public final void drawCustomTooltip(GuiScreen gui, double mouseX, double mouseY, double scale, int scaleAdj) {
+        drawCustomTooltip(gui.mc.fontRenderer, (int) mouseX, (int) mouseY, gui.width, gui.height);
+    }
+
+    @Override
+    public void onActionKeyPressed() {}
+}

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/steps/UniversalRenderStep.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/steps/UniversalRenderStep.java
@@ -5,22 +5,15 @@ import javax.annotation.Nullable;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 
-import org.joml.Vector2d;
 import org.lwjgl.opengl.GL11;
 
 import com.gtnewhorizons.navigator.api.NavigatorApi;
-import com.gtnewhorizons.navigator.api.journeymap.drawsteps.JMRenderStep;
 import com.gtnewhorizons.navigator.api.model.locations.ILocationProvider;
 import com.gtnewhorizons.navigator.api.util.DrawUtils;
 import com.gtnewhorizons.navigator.api.xaero.rendersteps.XaeroRenderStep;
 
-import cpw.mods.fml.common.Optional;
-import journeymap.client.render.map.GridRenderer;
+public abstract class UniversalRenderStep<T extends ILocationProvider> implements XaeroRenderStep {
 
-@Optional.Interface(iface = "com.gtnewhorizons.navigator.api.journeymap.drawsteps.JMRenderStep", modid = "journeymap")
-public abstract class UniversalRenderStep<T extends ILocationProvider> implements JMRenderStep, XaeroRenderStep {
-
-    private final Vector2d pos = new Vector2d();
     protected double fontScale = 1;
     protected double rotation = 0;
     protected double width = NavigatorApi.CHUNK_WIDTH;
@@ -68,21 +61,15 @@ public abstract class UniversalRenderStep<T extends ILocationProvider> implement
         GL11.glPopMatrix();
     }
 
-    @Override
-    public final void draw(double draggedPixelX, double draggedPixelY, GridRenderer gridRenderer, float drawScale,
+    public final void drawJourneyMap(double x, double y, float drawScale, double zoom, double blockSize,
         double fontScale, double rotation) {
         this.fontScale = fontScale;
         this.rotation = rotation;
         isJourneyMap = true;
-        zoom = gridRenderer.getZoom();
-        Vector2d blockPos = getBlockFromGrid(
-            gridRenderer,
-            draggedPixelX,
-            draggedPixelY,
-            location.getBlockX(),
-            location.getBlockZ());
-        x = blockPos.x;
-        y = blockPos.y;
+        this.zoom = zoom;
+        this.blockSize = blockSize;
+        this.x = x;
+        this.y = y;
         preRender(getX(), getY(), drawScale, zoom);
         GL11.glPushMatrix();
         DrawUtils.setupDrawing();
@@ -175,15 +162,6 @@ public abstract class UniversalRenderStep<T extends ILocationProvider> implement
     @Override
     public T getLocation() {
         return location;
-    }
-
-    private Vector2d getBlockFromGrid(GridRenderer gridRenderer, double pixelX, double pixelY, double x, double z) {
-        blockSize = (int) Math.pow(2.0, gridRenderer.getZoom());
-        double localBlockX = x - gridRenderer.getCenterBlockX();
-        double localBlockZ = z - gridRenderer.getCenterBlockZ();
-        double pixelOffsetX = (double) (gridRenderer.getWidth() / 2) + localBlockX * blockSize;
-        double pixelOffsetZ = (double) (gridRenderer.getHeight() / 2) + localBlockZ * blockSize;
-        return pos.set(pixelOffsetX + pixelX, pixelOffsetZ + pixelY);
     }
 
     private int getXaeroZoomAsSteps(double zoom) {

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/steps/UniversalRenderStep.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/steps/UniversalRenderStep.java
@@ -201,6 +201,15 @@ public abstract class UniversalRenderStep<T extends ILocationProvider> implement
      * @param minScale scale at which the step stops shrinking
      */
     public void setMinScale(int minScale) {
+        setMinScale((double) minScale);
+    }
+
+    /**
+     * Sets the lower Xaero scale bound used to keep an element legible while zooming out.
+     *
+     * @param minScale scale at which the step stops shrinking
+     */
+    public void setMinScale(double minScale) {
         this.minScale = minScale;
         shouldScale = true;
     }

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/steps/UniversalRenderStep.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/steps/UniversalRenderStep.java
@@ -12,6 +12,14 @@ import com.gtnewhorizons.navigator.api.model.locations.ILocationProvider;
 import com.gtnewhorizons.navigator.api.util.DrawUtils;
 import com.gtnewhorizons.navigator.api.xaero.rendersteps.XaeroRenderStep;
 
+/**
+ * Map-neutral render step used by JourneyMap and Xaero integrations.
+ * <p>
+ * Navigator calculates map-space position, applies integration scaling, configures basic OpenGL drawing state, and
+ * calls {@link #draw(double, double, float, double)}. Subclasses own any additional GL state they change.
+ *
+ * @param <T> source location type
+ */
 public abstract class UniversalRenderStep<T extends ILocationProvider> implements XaeroRenderStep {
 
     protected double fontScale = 1;
@@ -28,14 +36,30 @@ public abstract class UniversalRenderStep<T extends ILocationProvider> implement
     protected double minScale;
     protected boolean shouldScale;
 
+    /**
+     * @param location source location retained for the lifetime of this cached step
+     */
     public UniversalRenderStep(T location) {
         this.location = location;
     }
 
+    /**
+     * Draws the element in the active map integration.
+     *
+     * @param x         calculated map-space X including the configured offset
+     * @param y         calculated map-space Y/Z including the configured offset
+     * @param drawScale GUI/map scale supplied by the integration
+     * @param zoom      integration zoom value; prefer {@link #getZoomStep()} for thresholds
+     */
     public abstract void draw(double x, double y, float drawScale, double zoom);
 
     /**
-     * Do any setup that needs to happen prior to rendering.
+     * Updates derived state immediately before rendering.
+     *
+     * @param x         current map-space X
+     * @param y         current map-space Y/Z
+     * @param drawScale GUI/map scale supplied by the integration
+     * @param zoom      current integration zoom value
      */
     public void preRender(double x, double y, float drawScale, double zoom) {}
 
@@ -61,6 +85,17 @@ public abstract class UniversalRenderStep<T extends ILocationProvider> implement
         GL11.glPopMatrix();
     }
 
+    /**
+     * JourneyMap render entry point used by Navigator's integration.
+     *
+     * @param x         map-space X
+     * @param y         map-space Y/Z
+     * @param drawScale JourneyMap draw scale
+     * @param zoom      Navigator/JourneyMap zoom step
+     * @param blockSize pixels per world block
+     * @param fontScale JourneyMap font scale
+     * @param rotation  map rotation in degrees
+     */
     public final void drawJourneyMap(double x, double y, float drawScale, double zoom, double blockSize,
         double fontScale, double rotation) {
         this.fontScale = fontScale;
@@ -78,87 +113,123 @@ public abstract class UniversalRenderStep<T extends ILocationProvider> implement
     }
 
     /**
-     * Only applies to Xaero's if used in the constructor.
-     * If needed for both mods it should be set in {@link #preRender(double, double, float, double)}
+     * Sets a custom font scale.
+     * <p>
+     * Constructor-time values affect Xaero. Set it from {@link #preRender(double, double, float, double)} when both
+     * integrations need the value.
+     *
+     * @param fontScale scale multiplier
      */
     public void setFontScale(double fontScale) {
         this.fontScale = fontScale;
     }
 
+    /**
+     * Sets the logical element size in world blocks.
+     *
+     * @param width  width in blocks
+     * @param height height in blocks
+     */
     public void setSize(double width, double height) {
         this.width = width;
         this.height = height;
     }
 
+    /** @param size square logical size in world blocks */
     public void setSize(double size) {
         setSize(size, size);
     }
 
+    /**
+     * Sets a map-space offset applied after the integration calculates the location position.
+     *
+     * @param offsetX horizontal offset
+     * @param offsetY vertical/Z offset
+     */
     public void setOffset(double offsetX, double offsetY) {
         this.offsetX = offsetX;
         this.offsetY = offsetY;
     }
 
+    /** @param offset offset applied to both axes */
     public void setOffset(double offset) {
         setOffset(offset, offset);
     }
 
+    /** @return current integration font scale */
     public double getFontScale() {
         return fontScale;
     }
 
     /**
-     * Gives a consistent width regardless of mod
+     * @return logical width converted to the active integration's map space
      */
     public double getAdjustedWidth() {
         return width * blockSize;
     }
 
     /**
-     * Gives a consistent height regardless of mod
+     * @return logical height converted to the active integration's map space
      */
     public double getAdjustedHeight() {
         return height * blockSize;
     }
 
+    /** @return configured logical width in blocks */
     public double getWidth() {
         return width;
     }
 
+    /** @return configured logical height in blocks */
     public double getHeight() {
         return height;
     }
 
+    /** @return current calculated X plus configured offset */
     public double getX() {
         return x + offsetX;
     }
 
+    /** @return current calculated Y/Z plus configured offset */
     public double getY() {
         return y + offsetY;
     }
 
     /**
-     * Only relevant for Xaero's maps
-     * 
-     * @param minScale the zoom level at which the RenderStep should stop scaling
+     * Sets the lower Xaero scale bound used to keep an element legible while zooming out.
+     *
+     * @param minScale scale at which the step stops shrinking
      */
     public void setMinScale(int minScale) {
         this.minScale = minScale;
         shouldScale = true;
     }
 
+    /**
+     * @param currentScale active Xaero scale
+     * @return scale clamped to the configured minimum
+     */
     public double getScaling(double currentScale) {
         return Math.max(currentScale, minScale);
     }
 
+    /**
+     * @return {@code true} when no fullscreen GUI is open; primarily useful for minimizing minimap detail
+     */
     public boolean isMinimap() {
         return Minecraft.getMinecraft().currentScreen == null;
     }
 
+    /**
+     * Returns a cross-map zoom step suitable for visibility thresholds.
+     *
+     * @return JourneyMap's supplied zoom step or Xaero's scale converted to steps {@code 0..5}
+     */
     public double getZoomStep() {
         return isXaero ? getXaeroZoomAsSteps(zoom) : zoom;
     }
 
+    /** @return source location */
     @Override
     public T getLocation() {
         return location;

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/steps/UniversalRenderStep.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/steps/UniversalRenderStep.java
@@ -238,6 +238,31 @@ public abstract class UniversalRenderStep<T extends ILocationProvider> implement
         return isXaero ? getXaeroZoomAsSteps(zoom) : zoom;
     }
 
+    /**
+     * Interpolates a scale across a normalized zoom range, clamping outside it.
+     * <p>
+     * This is an additional on-screen size multiplier. Xaero steps using {@link #setMinScale(double)} already
+     * compensate for Xaero's raw zoom transform, so apply this multiplier there only when the element should visibly
+     * resize rather than merely retain its size.
+     *
+     * @param minScale scale at {@code minZoom}
+     * @param maxScale scale at {@code maxZoom}
+     * @param minZoom  normalized zoom step where scaling starts
+     * @param maxZoom  normalized zoom step where scaling ends; must be greater than {@code minZoom}
+     * @return scale for the active map's current zoom
+     */
+    public double getZoomScale(double minScale, double maxScale, double minZoom, double maxZoom) {
+        return interpolateZoomScale(getZoomStep(), minScale, maxScale, minZoom, maxZoom);
+    }
+
+    /** Interpolates a scale for a supplied normalized zoom step. */
+    public static double interpolateZoomScale(double zoomStep, double minScale, double maxScale, double minZoom,
+        double maxZoom) {
+        if (maxZoom <= minZoom) throw new IllegalArgumentException("maxZoom must be greater than minZoom");
+        double progress = (zoomStep - minZoom) / (maxZoom - minZoom);
+        return minScale + (maxScale - minScale) * Math.max(0, Math.min(1, progress));
+    }
+
     /** @return source location */
     @Override
     public T getLocation() {

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/waypoints/Waypoint.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/waypoints/Waypoint.java
@@ -1,5 +1,6 @@
 package com.gtnewhorizons.navigator.api.model.waypoints;
 
+/** Immutable map-neutral waypoint value published by a waypoint-capable location. */
 public class Waypoint {
 
     public final int blockX;
@@ -9,6 +10,14 @@ public class Waypoint {
     public final String label;
     public final int color;
 
+    /**
+     * @param blockX      world block X
+     * @param blockY      world block Y
+     * @param blockZ      world block Z
+     * @param dimensionId dimension containing the waypoint
+     * @param label       display label
+     * @param color       RGB color
+     */
     public Waypoint(int blockX, int blockY, int blockZ, int dimensionId, String label, int color) {
         this.blockX = blockX;
         this.blockY = blockY;

--- a/src/main/java/com/gtnewhorizons/navigator/api/model/waypoints/WaypointManager.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/waypoints/WaypointManager.java
@@ -3,6 +3,7 @@ package com.gtnewhorizons.navigator.api.model.waypoints;
 import com.gtnewhorizons.navigator.api.model.SupportedMods;
 import com.gtnewhorizons.navigator.api.model.layers.InteractableLayerManager;
 
+/** Bridges one interactable layer's active waypoint into a specific map mod. */
 public abstract class WaypointManager {
 
     protected final InteractableLayerManager manager;
@@ -13,9 +14,12 @@ public abstract class WaypointManager {
         this.mod = mod;
     }
 
+    /** Clears the map-specific waypoint owned by this manager. */
     public abstract void clearActiveWaypoint();
 
+    /** Creates or updates the map-specific waypoint from Navigator's value. */
     public abstract void updateActiveWaypoint(Waypoint waypoint);
 
+    /** @return whether this manager currently owns a map-specific waypoint */
     public abstract boolean hasWaypoint();
 }

--- a/src/main/java/com/gtnewhorizons/navigator/api/util/ClickPos.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/util/ClickPos.java
@@ -3,15 +3,21 @@ package com.gtnewhorizons.navigator.api.util;
 import javax.annotation.Nullable;
 
 import com.gtnewhorizons.navigator.api.model.steps.InteractableStep;
+import com.gtnewhorizons.navigator.api.model.steps.LocationInteractableStep;
 
 public class ClickPos {
 
     private boolean doubleClick;
     private int mouseX, mouseY, blockX, blockZ;
-    private InteractableStep renderStep;
+    private LocationInteractableStep renderStep;
 
     public ClickPos set(@Nullable InteractableStep renderStep, boolean doubleClick, int mouseX, int mouseY, int blockX,
         int blockZ) {
+        return set((LocationInteractableStep) renderStep, doubleClick, mouseX, mouseY, blockX, blockZ);
+    }
+
+    public ClickPos set(@Nullable LocationInteractableStep renderStep, boolean doubleClick, int mouseX, int mouseY,
+        int blockX, int blockZ) {
         this.renderStep = renderStep;
         this.doubleClick = doubleClick;
         this.mouseX = mouseX;
@@ -50,6 +56,10 @@ public class ClickPos {
     }
 
     public @Nullable InteractableStep getRenderStep() {
+        return renderStep instanceof InteractableStep interactableStep ? interactableStep : null;
+    }
+
+    public @Nullable LocationInteractableStep getLocationRenderStep() {
         return renderStep;
     }
 

--- a/src/main/java/com/gtnewhorizons/navigator/api/util/ClickPos.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/util/ClickPos.java
@@ -5,17 +5,33 @@ import javax.annotation.Nullable;
 import com.gtnewhorizons.navigator.api.model.steps.InteractableStep;
 import com.gtnewhorizons.navigator.api.model.steps.LocationInteractableStep;
 
+/**
+ * Reused click-event view passed to {@code UniversalInteractableRenderer.withClickAction} callbacks.
+ * <p>
+ * Do not retain this mutable object after the callback returns. Use {@link #getLocationRenderStep()} for new code;
+ * {@link #getRenderStep()} is the waypoint-only compatibility accessor.
+ */
 public class ClickPos {
 
     private boolean doubleClick;
     private int mouseX, mouseY, blockX, blockZ;
     private LocationInteractableStep renderStep;
 
+    /**
+     * Populates this event using a legacy waypoint-capable step.
+     *
+     * @return this reused event instance
+     */
     public ClickPos set(@Nullable InteractableStep renderStep, boolean doubleClick, int mouseX, int mouseY, int blockX,
         int blockZ) {
         return set((LocationInteractableStep) renderStep, doubleClick, mouseX, mouseY, blockX, blockZ);
     }
 
+    /**
+     * Populates this event using any location-interactable step.
+     *
+     * @return this reused event instance
+     */
     public ClickPos set(@Nullable LocationInteractableStep renderStep, boolean doubleClick, int mouseX, int mouseY,
         int blockX, int blockZ) {
         this.renderStep = renderStep;
@@ -27,38 +43,53 @@ public class ClickPos {
         return this;
     }
 
+    /** @return whether the map classified this event as a double-click */
     public boolean isDoubleClick() {
         return doubleClick;
     }
 
+    /** @return mouse X in GUI coordinates */
     public int getMouseX() {
         return mouseX;
     }
 
+    /** @return mouse Y in GUI coordinates */
     public int getMouseY() {
         return mouseY;
     }
 
+    /** @return world block X under the pointer */
     public int getBlockX() {
         return blockX;
     }
 
+    /** @return world block Z under the pointer */
     public int getBlockZ() {
         return blockZ;
     }
 
+    /** @return chunk X under the pointer */
     public int getChunkX() {
         return Util.coordBlockToChunk(blockX);
     }
 
+    /** @return chunk Z under the pointer */
     public int getChunkZ() {
         return Util.coordBlockToChunk(blockZ);
     }
 
+    /**
+     * Returns the hovered legacy waypoint-capable step.
+     *
+     * @return hovered step, or {@code null} for empty space and plain-location interactable steps
+     */
     public @Nullable InteractableStep getRenderStep() {
         return renderStep instanceof InteractableStep interactableStep ? interactableStep : null;
     }
 
+    /**
+     * @return hovered location-interactable step, or {@code null} for empty space
+     */
     public @Nullable LocationInteractableStep getLocationRenderStep() {
         return renderStep;
     }

--- a/src/main/java/com/gtnewhorizons/navigator/api/util/DrawUtils.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/util/DrawUtils.java
@@ -13,9 +13,16 @@ import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;
 
+/**
+ * Immediate-mode drawing helpers used by Navigator render steps.
+ * <p>
+ * Colors are RGB integers unless documented otherwise; alpha arguments use {@code 0..255}. Methods configure the GL
+ * state they require but callers remain responsible for restoring any additional state they change.
+ */
 @SuppressWarnings("unused")
 public class DrawUtils {
 
+    /** Draws a vertical ARGB gradient rectangle at an explicit Z level. */
     public static void drawGradientRect(double minPixelX, double minPixelY, double maxPixelX, double maxPixelY,
         double z, int colorA, int colorB) {
         GL11.glDisable(GL11.GL_TEXTURE_2D);
@@ -49,11 +56,13 @@ public class DrawUtils {
         GL11.glEnable(GL11.GL_TEXTURE_2D);
     }
 
+    /** Draws a vertical ARGB gradient rectangle at Navigator's default tooltip Z level. */
     public static void drawGradientRect(double minPixelX, double minPixelY, double maxPixelX, double maxPixelY,
         int colorA, int colorB) {
         drawGradientRect(minPixelX, minPixelY, maxPixelX, maxPixelY, 300, colorA, colorB);
     }
 
+    /** Draws a full Minecraft texture resource as a tinted quad. */
     public static void drawQuad(ResourceLocation texture, double x, double y, double width, double height, int color,
         int alpha) {
         GL11.glEnable(GL11.GL_BLEND);
@@ -68,11 +77,13 @@ public class DrawUtils {
         tessellator.draw();
     }
 
+    /** Draws a full Minecraft texture resource as a tinted quad. */
     public static void drawQuad(ResourceLocation texture, double x, double y, double width, double height, int color,
         float alpha) {
         drawQuad(texture, x, y, width, height, color, (int) alpha);
     }
 
+    /** Draws a block/item icon from the block texture atlas. */
     public static void drawQuad(IIcon icon, double x, double y, double width, double height, int color, int alpha) {
         GL11.glEnable(GL11.GL_BLEND);
         OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 0);
@@ -97,10 +108,12 @@ public class DrawUtils {
         tessellator.draw();
     }
 
+    /** Draws a block/item icon from the block texture atlas. */
     public static void drawQuad(IIcon icon, double x, double y, double width, double height, int color, float alpha) {
         drawQuad(icon, x, y, width, height, color, (int) alpha);
     }
 
+    /** Adds an untextured rectangle to an already-started tessellator buffer. */
     public static void addRectToBuffer(Tessellator tessellator, double x, double y, double w, double h, int color,
         int alpha) {
         int[] c = ints(color, alpha);
@@ -111,6 +124,7 @@ public class DrawUtils {
         tessellator.addVertex(x, y, 0D);
     }
 
+    /** Adds a textured rectangle to an already-started tessellator buffer. */
     public static void addRectToBufferWithUV(Tessellator tessellator, double x, double y, double w, double h, int color,
         int alpha, double u0, double v0, double u1, double v1) {
         int[] c = ints(color, alpha);
@@ -121,6 +135,7 @@ public class DrawUtils {
         tessellator.addVertexWithUV(x, y, 0D, u0, v0);
     }
 
+    /** Draws a solid untextured rectangle. */
     public static void drawRect(double x, double y, double w, double h, int color, int alpha) {
         GL11.glDisable(GL11.GL_TEXTURE_2D);
         Tessellator tessellator = Tessellator.instance;
@@ -130,6 +145,7 @@ public class DrawUtils {
         GL11.glEnable(GL11.GL_TEXTURE_2D);
     }
 
+    /** Configures white color, disabled lighting, alpha blending, and the standard blend function. */
     public static void setupDrawing() {
         GL11.glColor4f(1F, 1F, 1F, 1F);
         GL11.glDisable(GL11.GL_LIGHTING);
@@ -137,6 +153,7 @@ public class DrawUtils {
         OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 0);
     }
 
+    /** Draws a one-line label using a supplied GUI. */
     public static void drawSimpleLabel(GuiScreen gui, String text, double textX, double textY, int fontColor,
         int bgColor, boolean centered) {
         GL11.glPushMatrix();
@@ -149,6 +166,7 @@ public class DrawUtils {
         GL11.glPopMatrix();
     }
 
+    /** Draws a one-line label using Minecraft's current font renderer. */
     public static void drawSimpleLabel(String text, double textX, double textY, int fontColor, int bgColor,
         boolean centered) {
         Minecraft mc = Minecraft.getMinecraft();
@@ -166,10 +184,12 @@ public class DrawUtils {
         GL11.glPopMatrix();
     }
 
+    /** Draws a one-pixel hollow rectangle. */
     public static void drawHollowRect(double x, double y, double w, double h, int col, int alpha) {
         drawHollowRect(x, y, w, h, col, alpha, 1);
     }
 
+    /** Draws a hollow rectangle with configurable line thickness. */
     public static void drawHollowRect(double x, double y, double w, double h, int col, int alpha, double thickness) {
         GL11.glDisable(GL11.GL_TEXTURE_2D);
         Tessellator tessellator = Tessellator.instance;
@@ -184,6 +204,7 @@ public class DrawUtils {
         GL11.glEnable(GL11.GL_TEXTURE_2D);
     }
 
+    /** Draws a simple multiline tooltip; an empty list is ignored. */
     public static void drawSimpleTooltip(GuiScreen gui, List<String> text, double x, double y, int fontColor,
         int bgColor) {
         if (text.isEmpty()) return;
@@ -216,16 +237,19 @@ public class DrawUtils {
         GL11.glPopMatrix();
     }
 
+    /** Draws a label at normal font scale with shadow. */
     public static void drawLabel(String text, double textX, double textY, int fontColor, int bgColor,
         boolean centered) {
         drawLabel(text, textX, textY, fontColor, bgColor, centered, 1.0);
     }
 
+    /** Draws a scaled label with shadow. */
     public static void drawLabel(String text, double textX, double textY, int fontColor, int bgColor, boolean centered,
         double fontScale) {
         drawLabel(text, textX, textY, fontColor, bgColor, centered, true, fontScale);
     }
 
+    /** Draws a scaled label with optional shadow. */
     public static void drawLabel(String text, double textX, double textY, int fontColor, int bgColor, boolean centered,
         boolean fontShadow, double fontScale) {
         final FontRenderer fontRenderer = Minecraft.getMinecraft().fontRenderer;
@@ -257,11 +281,13 @@ public class DrawUtils {
         GL11.glPopMatrix();
     }
 
+    /** Converts packed RGB to normalized float components. */
     public static float[] floats(int rgb) {
         return new float[] { (float) (rgb >> 16 & 255) / 255.0F, (float) (rgb >> 8 & 255) / 255.0F,
             (float) (rgb & 255) / 255.0F };
     }
 
+    /** Converts packed RGB and alpha to integer RGBA components. */
     public static int[] ints(int rgb, int alpha) {
         return new int[] { (rgb >> 16) & 255, (rgb >> 8) & 255, rgb & 255, alpha & 255 };
     }

--- a/src/main/java/com/gtnewhorizons/navigator/api/util/DrawUtils.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/util/DrawUtils.java
@@ -262,21 +262,18 @@ public class DrawUtils {
             GL11.glScaled(fontScale, fontScale, 0);
         }
 
-        double dTextX = textX - (double) (int) textX;
-        double dTextY = textY - (double) (int) textY;
         double textWidth = fontRenderer.getStringWidth(text);
-        double xOffsetL = centered ? -textWidth / 2.0 - 2 : -2;
+        double textLeft = centered ? textX - textWidth / 2.0 : textX;
+        int intTextX = (int) Math.floor(textLeft);
+        int intTextY = (int) Math.floor(textY);
+        double dTextX = textLeft - intTextX;
+        double dTextY = textY - intTextY;
+        drawRect(textLeft - 2, textY - 2, textWidth + 2, fontRenderer.FONT_HEIGHT + 2, bgColor, 180);
         GL11.glTranslated(dTextX, dTextY, 0.0);
-        drawRect(textX + xOffsetL, textY - 2, textWidth + 2, fontRenderer.FONT_HEIGHT + 2, bgColor, 180);
         if (fontShadow) {
-            fontRenderer.drawStringWithShadow(
-                text,
-                (centered ? (int) (textX - textWidth / 2.0) : (int) textX),
-                (int) textY,
-                fontColor);
+            fontRenderer.drawStringWithShadow(text, intTextX, intTextY, fontColor);
         } else {
-            fontRenderer
-                .drawString(text, (centered ? (int) (textX - textWidth / 2.0) : (int) textX), (int) textY, fontColor);
+            fontRenderer.drawString(text, intTextX, intTextY, fontColor);
         }
         GL11.glPopMatrix();
     }

--- a/src/main/java/com/gtnewhorizons/navigator/api/util/Util.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/util/Util.java
@@ -9,6 +9,7 @@ import com.gtnewhorizons.navigator.api.journeymap.JourneyMapVersion;
 
 import cpw.mods.fml.common.Loader;
 
+/** Cached optional-mod detection, coordinate conversion, packing, zoom, and key helpers. */
 public class Util {
 
     private static final JourneyMapVersion journeyMapVersion;
@@ -31,54 +32,71 @@ public class Util {
         }
     }
 
+    /** @return whether any supported JourneyMap generation is installed */
     public static boolean isJourneyMapInstalled() {
         return journeyMapVersion != JourneyMapVersion.NONE;
     }
 
+    /** @return whether the installed JourneyMap uses the legacy v5 API */
     public static boolean isJourneyMapV5Installed() {
         return journeyMapVersion == JourneyMapVersion.V5;
     }
 
+    /** @return whether the installed JourneyMap exposes the v2 API used by the 1.7.10 v6 backport */
     public static boolean isJourneyMapV6Installed() {
         return journeyMapVersion == JourneyMapVersion.V6;
     }
 
+    /** @return cached JourneyMap generation */
     public static JourneyMapVersion getJourneyMapVersion() {
         return journeyMapVersion;
     }
 
+    /** @return whether Xaero's World Map is installed */
     public static boolean isXaerosWorldMapInstalled() {
         return isXaeroWorldMapLoaded;
     }
 
+    /** @return whether Xaero's Minimap is installed */
     public static boolean isXaerosMinimapInstalled() {
         return isXaeroMinimapLoaded;
     }
 
+    /** @return whether the supported VoxelMap class is present */
     public static boolean isVoxelMapInstalled() {
         return isVoxelMapLoaded;
     }
 
+    /** @return whether NotEnoughItems is installed */
     public static boolean isNEIInstalled() {
         return isNEILoaded;
     }
 
+    /**
+     * Converts a block coordinate to its containing chunk with correct negative-coordinate flooring.
+     */
     public static int coordBlockToChunk(int blockCoord) {
         return blockCoord < 0 ? -((-blockCoord - 1) >> 4) - 1 : blockCoord >> 4;
     }
 
+    /** Converts a chunk coordinate to the block coordinate of its minimum edge. */
     public static int coordChunkToBlock(int chunkCoord) {
         return chunkCoord < 0 ? -((-chunkCoord) << 4) : chunkCoord << 4;
     }
 
+    /** Packs chunk X/Z into Navigator's location key format. */
     public static long packChunkToLocation(int chunkX, int chunkZ) {
         return CoordinatePacker.pack(chunkX, 0, chunkZ);
     }
 
+    /** Converts JourneyMap's exponential zoom step to a linear scale. */
     public static double journeyMapScaleToLinear(final int jzoom) {
         return Math.pow(2, jzoom);
     }
 
+    /**
+     * @return whether a key binding emitted a press or is currently held
+     */
     public static boolean isKeyPressed(KeyBinding key) {
         return key.isPressed() || Keyboard.isKeyDown(key.getKeyCode());
     }

--- a/src/main/java/com/gtnewhorizons/navigator/api/util/Util.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/util/Util.java
@@ -74,12 +74,12 @@ public class Util {
      * Converts a block coordinate to its containing chunk with correct negative-coordinate flooring.
      */
     public static int coordBlockToChunk(int blockCoord) {
-        return blockCoord < 0 ? -((-blockCoord - 1) >> 4) - 1 : blockCoord >> 4;
+        return blockCoord >> 4;
     }
 
     /** Converts a chunk coordinate to the block coordinate of its minimum edge. */
     public static int coordChunkToBlock(int chunkCoord) {
-        return chunkCoord < 0 ? -((-chunkCoord) << 4) : chunkCoord << 4;
+        return chunkCoord << 4;
     }
 
     /** Packs chunk X/Z into Navigator's location key format. */

--- a/src/main/java/com/gtnewhorizons/navigator/api/util/Util.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/util/Util.java
@@ -12,14 +12,12 @@ import cpw.mods.fml.common.Loader;
 /** Cached optional-mod detection, coordinate conversion, packing, zoom, and key helpers. */
 public class Util {
 
-    private static final JourneyMapVersion journeyMapVersion;
     private static final boolean isXaeroWorldMapLoaded;
     private static final boolean isXaeroMinimapLoaded;
     private static final boolean isNEILoaded;
     private static boolean isVoxelMapLoaded;
 
     static {
-        journeyMapVersion = JourneyMapVersion.get();
         isXaeroWorldMapLoaded = Loader.isModLoaded("XaeroWorldMap");
         isXaeroMinimapLoaded = Loader.isModLoaded("XaeroMinimap");
         isNEILoaded = Loader.isModLoaded("NotEnoughItems");
@@ -34,22 +32,22 @@ public class Util {
 
     /** @return whether any supported JourneyMap generation is installed */
     public static boolean isJourneyMapInstalled() {
-        return journeyMapVersion != JourneyMapVersion.NONE;
+        return JourneyMapVersion.get() != JourneyMapVersion.NONE;
     }
 
     /** @return whether the installed JourneyMap uses the legacy v5 API */
     public static boolean isJourneyMapV5Installed() {
-        return journeyMapVersion == JourneyMapVersion.V5;
+        return JourneyMapVersion.get() == JourneyMapVersion.V5;
     }
 
     /** @return whether the installed JourneyMap exposes the v2 API used by the 1.7.10 v6 backport */
     public static boolean isJourneyMapV6Installed() {
-        return journeyMapVersion == JourneyMapVersion.V6;
+        return JourneyMapVersion.get() == JourneyMapVersion.V6;
     }
 
     /** @return cached JourneyMap generation */
     public static JourneyMapVersion getJourneyMapVersion() {
-        return journeyMapVersion;
+        return JourneyMapVersion.get();
     }
 
     /** @return whether Xaero's World Map is installed */

--- a/src/main/java/com/gtnewhorizons/navigator/api/voxelmap/VoxelMapWaypointManager.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/voxelmap/VoxelMapWaypointManager.java
@@ -9,10 +9,16 @@ import com.thevoxelbox.voxelmap.interfaces.AbstractVoxelMap;
 import com.thevoxelbox.voxelmap.interfaces.IWaypointManager;
 import com.thevoxelbox.voxelmap.util.Waypoint;
 
+/**
+ * Optional VoxelMap waypoint helpers.
+ * <p>
+ * Navigator does not provide VoxelMap layer rendering. Calls are safe no-ops when VoxelMap is absent.
+ */
 public class VoxelMapWaypointManager {
 
     private static Method getCurrentSubworldDescriptor;
 
+    /** Adds an already-created VoxelMap waypoint when VoxelMap is installed. */
     public static void addVoxelMapWaypoint(Waypoint waypoint) {
         if (!Util.isVoxelMapInstalled()) return;
         IWaypointManager waypointManager = AbstractVoxelMap.getInstance()
@@ -20,6 +26,7 @@ public class VoxelMapWaypointManager {
         waypointManager.addWaypoint(waypoint);
     }
 
+    /** Creates and adds a VoxelMap waypoint when VoxelMap is installed. */
     public static void addVoxelMapWaypoint(String name, int x, int y, int z, boolean enabled, float red, float green,
         float blue, String icon, TreeSet<Integer> dimension) {
         if (!Util.isVoxelMapInstalled()) return;
@@ -40,6 +47,11 @@ public class VoxelMapWaypointManager {
                 dimension));
     }
 
+    /**
+     * Invokes VoxelMap's obfuscated current-subworld method.
+     *
+     * @return current subworld descriptor, or an empty string if reflection failed
+     */
     public static String getCurrentSubworldDescriptor(IWaypointManager obj, boolean arg) {
         try {
             return (String) getCurrentSubworldDescriptor.invoke(obj, arg);

--- a/src/main/java/com/gtnewhorizons/navigator/api/xaero/buttons/SizedGuiTexturedButton.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/xaero/buttons/SizedGuiTexturedButton.java
@@ -12,6 +12,7 @@ import org.lwjgl.opengl.GL11;
 import xaero.map.gui.CursorBox;
 import xaero.map.gui.GuiTexturedButton;
 
+/** Xaero textured layer button with Navigator's fixed 20x20 frame, centered 16x16 icon, and active tint. */
 public class SizedGuiTexturedButton extends GuiTexturedButton {
 
     private static final int BUTTON_WIDTH = 20;
@@ -56,10 +57,12 @@ public class SizedGuiTexturedButton extends GuiTexturedButton {
         Gui.func_146110_a(iconX, iconY, textureX, textureY, textureW, textureH, textureW, textureH);
     }
 
+    /** @return whether the pointer is inside the full button frame */
     public boolean isMouseOver(int mouseX, int mouseY) {
         return mouseX >= xPosition && mouseY >= yPosition && mouseX < xPosition + width && mouseY < yPosition + height;
     }
 
+    /** Sets the visual active tint independently from the inherited enabled state. */
     public void setActive(boolean active) {
         this.active = active;
     }

--- a/src/main/java/com/gtnewhorizons/navigator/api/xaero/renderers/XaeroInteractableLayerRenderer.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/xaero/renderers/XaeroInteractableLayerRenderer.java
@@ -13,6 +13,11 @@ import com.gtnewhorizons.navigator.api.model.layers.InteractableLayerManager;
 import com.gtnewhorizons.navigator.api.xaero.rendersteps.XaeroInteractableStep;
 import com.gtnewhorizons.navigator.api.xaero.rendersteps.XaeroRenderStep;
 
+/**
+ * Xaero-specific renderer with hover, tooltip, action-key, and default waypoint double-click handling.
+ * <p>
+ * Prefer {@link com.gtnewhorizons.navigator.api.model.layers.UniversalInteractableRenderer} for new layers.
+ */
 public abstract class XaeroInteractableLayerRenderer extends XaeroLayerRenderer implements InteractableLayer {
 
     protected InteractableLayerManager manager;
@@ -23,6 +28,7 @@ public abstract class XaeroInteractableLayerRenderer extends XaeroLayerRenderer 
         this.manager = manager;
     }
 
+    /** Updates the hovered step from Xaero map-space coordinates and scale. */
     public void updateHovered(double mouseX, double mouseY, double scale) {
         for (XaeroRenderStep step : getReversedRenderSteps()) {
             if (step instanceof XaeroInteractableStep interactableRenderStep
@@ -34,6 +40,7 @@ public abstract class XaeroInteractableLayerRenderer extends XaeroLayerRenderer 
         hovered = null;
     }
 
+    /** Draws the hovered step's Xaero-specific custom tooltip. */
     public void drawCustomTooltip(GuiScreen gui, double mouseX, double mouseY, double scale, int scaleAdj) {
         if (hovered != null) {
             hovered.drawCustomTooltip(gui, mouseX, mouseY, scale, scaleAdj);
@@ -71,6 +78,7 @@ public abstract class XaeroInteractableLayerRenderer extends XaeroLayerRenderer 
 
     }
 
+    /** Applies the default double-click waypoint toggle to the hovered step. */
     public void onClick(boolean isDoubleClick, int mouseX, int mouseY, int mouseBlockX, int mouseBlockZ) {
         if (isDoubleClick) {
             if (hovered.getLocation()
@@ -84,6 +92,7 @@ public abstract class XaeroInteractableLayerRenderer extends XaeroLayerRenderer 
         }
     }
 
+    /** Hook for clicks outside all render steps. */
     public void onClickOutsideRenderStep(boolean isDoubleClick, int mouseX, int mouseY, int mouseBlockX,
         int mouseBlockZ) {}
 

--- a/src/main/java/com/gtnewhorizons/navigator/api/xaero/renderers/XaeroLayerRenderer.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/xaero/renderers/XaeroLayerRenderer.java
@@ -9,6 +9,7 @@ import com.gtnewhorizons.navigator.api.model.layers.LayerManager;
 import com.gtnewhorizons.navigator.api.model.layers.LayerRenderer;
 import com.gtnewhorizons.navigator.api.xaero.rendersteps.XaeroRenderStep;
 
+/** Xaero World Map-specific renderer. Prefer {@code UniversalLayerRenderer} for new layers. */
 public abstract class XaeroLayerRenderer extends LayerRenderer {
 
     public XaeroLayerRenderer(@Nonnull LayerManager manager) {

--- a/src/main/java/com/gtnewhorizons/navigator/api/xaero/rendersteps/XaeroInteractableStep.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/xaero/rendersteps/XaeroInteractableStep.java
@@ -4,10 +4,13 @@ import net.minecraft.client.gui.GuiScreen;
 
 import com.gtnewhorizons.navigator.api.model.steps.InteractableStep;
 
+/** Xaero-specific interactable step for waypoint-capable locations. */
 public interface XaeroInteractableStep extends XaeroRenderStep, InteractableStep {
 
+    /** @return whether Xaero's map-space pointer is over this step */
     boolean isMouseOver(double mouseX, double mouseY, double scale);
 
+    /** Draws custom tooltip content using Xaero's GUI coordinates. */
     void drawCustomTooltip(GuiScreen gui, double mouseX, double mouseY, double scale, int scaleAdj);
 
     @Override
@@ -16,6 +19,8 @@ public interface XaeroInteractableStep extends XaeroRenderStep, InteractableStep
     }
 
     /**
+     * Legacy action hook.
+     *
      * @deprecated Use {@link #onActionKeyPressed()} instead
      */
     @Deprecated

--- a/src/main/java/com/gtnewhorizons/navigator/api/xaero/rendersteps/XaeroRenderStep.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/xaero/rendersteps/XaeroRenderStep.java
@@ -6,10 +6,13 @@ import net.minecraft.client.gui.GuiScreen;
 
 import com.gtnewhorizons.navigator.api.model.steps.RenderStep;
 
+/** Xaero-specific render step. Prefer {@code UniversalRenderStep} for new layers. */
 public interface XaeroRenderStep extends RenderStep {
 
+    /** Draws a step using Xaero's camera and scale. */
     void draw(@Nullable GuiScreen gui, double cameraX, double cameraZ, double scale);
 
+    /** Optional Xaero draw path that also exposes GUI-based scale. */
     default void draw(double cameraX, double cameraZ, double scale, float guiBasedScale) {
 
     }

--- a/src/main/java/com/gtnewhorizons/navigator/api/xaero/waypoints/WaypointWithDimension.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/xaero/waypoints/WaypointWithDimension.java
@@ -2,6 +2,7 @@ package com.gtnewhorizons.navigator.api.xaero.waypoints;
 
 import xaero.common.minimap.waypoints.Waypoint;
 
+/** Xaero waypoint that disables itself whenever the player is outside its owning dimension. */
 public class WaypointWithDimension extends Waypoint {
 
     private final int dimID;
@@ -13,10 +14,12 @@ public class WaypointWithDimension extends Waypoint {
         this.currentDim = dimID;
     }
 
+    /** Updates the dimension used by {@link #isDisabled()}. */
     public void notifyDimension(int newDimID) {
         currentDim = newDimID;
     }
 
+    /** @return dimension containing this waypoint */
     public int getDimID() {
         return dimID;
     }

--- a/src/main/java/com/gtnewhorizons/navigator/api/xaero/waypoints/XaeroWaypointManager.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/xaero/waypoints/XaeroWaypointManager.java
@@ -10,6 +10,7 @@ import com.gtnewhorizons.navigator.api.model.waypoints.WaypointManager;
 
 import xaero.common.minimap.waypoints.WaypointsManager;
 
+/** Publishes one Navigator-owned waypoint into Xaero's custom waypoint collection. */
 public class XaeroWaypointManager extends WaypointManager {
 
     public static int lastId;
@@ -17,11 +18,18 @@ public class XaeroWaypointManager extends WaypointManager {
     private WaypointWithDimension xWaypoint;
     private String symbol = "";
 
+    /**
+     * Creates a manager using the first character of the waypoint label as its Xaero symbol.
+     */
     public XaeroWaypointManager(InteractableLayerManager layerManager) {
         super(layerManager, SupportedMods.XaeroMiniMap);
         waypointId = lastId++;
     }
 
+    /**
+     * @param layerManager owning layer
+     * @param symbol       fixed Xaero symbol; an empty value uses the label's first character
+     */
     public XaeroWaypointManager(InteractableLayerManager layerManager, String symbol) {
         this(layerManager);
         this.symbol = symbol;
@@ -38,6 +46,7 @@ public class XaeroWaypointManager extends WaypointManager {
         return xWaypoint != null;
     }
 
+    /** @return current Xaero waypoint including its dimension, or {@code null} */
     public WaypointWithDimension getXWaypoint() {
         return xWaypoint;
     }

--- a/src/main/java/com/gtnewhorizons/navigator/config/GeneralConfig.java
+++ b/src/main/java/com/gtnewhorizons/navigator/config/GeneralConfig.java
@@ -9,4 +9,8 @@ public class GeneralConfig {
     @Config.DefaultBoolean(false)
     public static boolean enableDebugLayers;
 
+    @Config.Comment("Keep the fullscreen map search text when reopening the map")
+    @Config.DefaultBoolean(true)
+    public static boolean rememberSearchText;
+
 }

--- a/src/main/java/com/gtnewhorizons/navigator/internal/SearchBar.java
+++ b/src/main/java/com/gtnewhorizons/navigator/internal/SearchBar.java
@@ -53,7 +53,8 @@ public class SearchBar extends FormattedTextField {
 
     public void setTextConsumer(Consumer<String> textConsumer) {
         this.textConsumer = textConsumer;
-        if (textConsumer != null) textConsumer.accept(getText());
+        oldText = getText();
+        if (textConsumer != null) textConsumer.accept(oldText);
     }
 
     public boolean isHovered(int mouseX, int mouseY) {

--- a/src/main/java/com/gtnewhorizons/navigator/internal/SearchBar.java
+++ b/src/main/java/com/gtnewhorizons/navigator/internal/SearchBar.java
@@ -53,6 +53,7 @@ public class SearchBar extends FormattedTextField {
 
     public void setTextConsumer(Consumer<String> textConsumer) {
         this.textConsumer = textConsumer;
+        if (textConsumer != null) textConsumer.accept(getText());
     }
 
     public boolean isHovered(int mouseX, int mouseY) {

--- a/src/main/java/com/gtnewhorizons/navigator/internal/SearchBar.java
+++ b/src/main/java/com/gtnewhorizons/navigator/internal/SearchBar.java
@@ -5,9 +5,12 @@ import java.util.function.Consumer;
 import net.minecraft.client.Minecraft;
 
 import com.gtnewhorizons.navigator.api.util.Util;
+import com.gtnewhorizons.navigator.config.GeneralConfig;
 import com.gtnewhorizons.navigator.internal.nei.NEISearchFormatter;
 
 public class SearchBar extends FormattedTextField {
+
+    private static String lastText = "";
 
     private Consumer<String> textConsumer;
 
@@ -16,6 +19,12 @@ public class SearchBar extends FormattedTextField {
     public SearchBar(int x, int y, int width, int height) {
         super(Minecraft.getMinecraft().fontRenderer, x, y, width, height);
         setFormatter(resolveFormatter());
+        if (GeneralConfig.rememberSearchText) setText(getRestoredText());
+        else lastText = "";
+    }
+
+    public static String getRestoredText() {
+        return GeneralConfig.rememberSearchText ? lastText : "";
     }
 
     private static TextFormatter resolveFormatter() {
@@ -45,6 +54,7 @@ public class SearchBar extends FormattedTextField {
 
         if (!getText().equals(oldText)) {
             oldText = getText();
+            lastText = oldText;
             if (textConsumer != null) {
                 textConsumer.accept(getText());
             }
@@ -52,9 +62,14 @@ public class SearchBar extends FormattedTextField {
     }
 
     public void setTextConsumer(Consumer<String> textConsumer) {
+        setTextConsumer(textConsumer, true);
+    }
+
+    public void setTextConsumer(Consumer<String> textConsumer, boolean notify) {
         this.textConsumer = textConsumer;
         oldText = getText();
-        if (textConsumer != null) textConsumer.accept(oldText);
+        lastText = oldText;
+        if (notify && textConsumer != null) textConsumer.accept(oldText);
     }
 
     public boolean isHovered(int mouseX, int mouseY) {

--- a/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/JourneyMapIntegration.java
+++ b/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/JourneyMapIntegration.java
@@ -10,7 +10,7 @@ public final class JourneyMapIntegration {
 
     public static void centerOn(int blockX, int blockZ, int zoom) {
         if (Util.isJourneyMapV6Installed()) {
-            JourneyMapV6Plugin.centerOn(blockX, blockZ);
+            JourneyMapV6Plugin.centerOn(blockX, blockZ, zoom);
         } else if (Util.isJourneyMapV5Installed()) {
             JourneyMapV5Fullscreen.centerOn(blockX, blockZ, zoom);
         }

--- a/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/JourneyMapIntegration.java
+++ b/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/JourneyMapIntegration.java
@@ -1,0 +1,18 @@
+package com.gtnewhorizons.navigator.internal.journeymap;
+
+import com.gtnewhorizons.navigator.api.util.Util;
+import com.gtnewhorizons.navigator.internal.journeymap.v5.JourneyMapV5Fullscreen;
+import com.gtnewhorizons.navigator.internal.journeymap.v6.JourneyMapV6Plugin;
+
+public final class JourneyMapIntegration {
+
+    private JourneyMapIntegration() {}
+
+    public static void centerOn(int blockX, int blockZ, int zoom) {
+        if (Util.isJourneyMapV6Installed()) {
+            JourneyMapV6Plugin.centerOn(blockX, blockZ);
+        } else if (Util.isJourneyMapV5Installed()) {
+            JourneyMapV5Fullscreen.centerOn(blockX, blockZ, zoom);
+        }
+    }
+}

--- a/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v5/JourneyMapV5Fullscreen.java
+++ b/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v5/JourneyMapV5Fullscreen.java
@@ -1,0 +1,18 @@
+package com.gtnewhorizons.navigator.internal.journeymap.v5;
+
+import com.gtnewhorizons.navigator.mixins.late.journeymap.FullscreenAccessor;
+
+import journeymap.client.render.map.GridRenderer;
+
+public final class JourneyMapV5Fullscreen {
+
+    private JourneyMapV5Fullscreen() {}
+
+    public static void centerOn(int blockX, int blockZ, int zoom) {
+        GridRenderer renderer = FullscreenAccessor.getGridRenderer();
+        if (renderer == null) return;
+
+        int targetZoom = zoom == -1 ? renderer.getZoom() : zoom;
+        renderer.center(renderer.getMapType(), blockX, blockZ, targetZoom);
+    }
+}

--- a/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v5/JourneyMapV5Renderer.java
+++ b/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v5/JourneyMapV5Renderer.java
@@ -1,0 +1,26 @@
+package com.gtnewhorizons.navigator.internal.journeymap.v5;
+
+import com.gtnewhorizons.navigator.api.journeymap.drawsteps.JMRenderStep;
+import com.gtnewhorizons.navigator.api.model.steps.RenderStep;
+import com.gtnewhorizons.navigator.api.model.steps.UniversalRenderStep;
+
+import journeymap.client.render.map.GridRenderer;
+
+public final class JourneyMapV5Renderer {
+
+    private JourneyMapV5Renderer() {}
+
+    public static void draw(RenderStep step, double pixelX, double pixelY, GridRenderer renderer, float drawScale,
+        double fontScale, double rotation) {
+        if (step instanceof JMRenderStep jmStep) {
+            jmStep.draw(pixelX, pixelY, renderer, drawScale, fontScale, rotation);
+        } else if (step instanceof UniversalRenderStep<?>universalStep) {
+            int blockSize = (int) Math.pow(2.0, renderer.getZoom());
+            double x = (double) (renderer.getWidth() / 2) + (universalStep.getLocation()
+                .getBlockX() - renderer.getCenterBlockX()) * blockSize + pixelX;
+            double y = (double) (renderer.getHeight() / 2) + (universalStep.getLocation()
+                .getBlockZ() - renderer.getCenterBlockZ()) * blockSize + pixelY;
+            universalStep.drawJourneyMap(x, y, drawScale, renderer.getZoom(), blockSize, fontScale, rotation);
+        }
+    }
+}

--- a/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
+++ b/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
@@ -1,5 +1,6 @@
 package com.gtnewhorizons.navigator.internal.journeymap.v6;
 
+import java.awt.Polygon;
 import java.awt.geom.Point2D;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -30,7 +31,7 @@ import com.gtnewhorizons.navigator.api.model.layers.UniversalInteractableRendere
 import com.gtnewhorizons.navigator.api.model.layers.UniversalLayerRenderer;
 import com.gtnewhorizons.navigator.api.model.locations.ILocationProvider;
 import com.gtnewhorizons.navigator.api.model.markers.MapMarker;
-import com.gtnewhorizons.navigator.api.model.steps.UniversalInteractableStep;
+import com.gtnewhorizons.navigator.api.model.steps.UniversalLocationInteractableStep;
 import com.gtnewhorizons.navigator.api.model.steps.UniversalRenderStep;
 import com.gtnewhorizons.navigator.api.util.DrawUtils;
 import com.gtnewhorizons.navigator.internal.SearchBar;
@@ -43,6 +44,8 @@ import journeymap.api.v2.client.IClientPlugin;
 import journeymap.api.v2.client.display.Displayable;
 import journeymap.api.v2.client.display.IOverlayListener;
 import journeymap.api.v2.client.display.MarkerOverlay;
+import journeymap.api.v2.client.display.Overlay;
+import journeymap.api.v2.client.display.PolygonOverlay;
 import journeymap.api.v2.client.event.DisplayUpdateEvent;
 import journeymap.api.v2.client.event.FullscreenDisplayEvent;
 import journeymap.api.v2.client.event.FullscreenMapEvent;
@@ -50,6 +53,7 @@ import journeymap.api.v2.client.event.FullscreenRenderEvent;
 import journeymap.api.v2.client.fullscreen.IFullscreen;
 import journeymap.api.v2.client.fullscreen.IThemeButton;
 import journeymap.api.v2.client.model.MapImage;
+import journeymap.api.v2.client.model.MapPolygon;
 import journeymap.api.v2.client.util.UIState;
 import journeymap.api.v2.common.Context;
 import journeymap.api.v2.common.JourneyMapPlugin;
@@ -73,7 +77,7 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
 
     private final Map<UniversalLayerRenderer, Map<ILocationProvider, List<Displayable>>> overlays = new IdentityHashMap<>();
     private final Map<LayerManager, Long> overlayRefreshVersions = new IdentityHashMap<>();
-    private @Nullable MarkerListener hoveredMarker;
+    private @Nullable OverlayListener hoveredOverlay;
     private boolean actionKeyDown;
     private boolean fullscreenActive;
     private long lastOverlayUpdate;
@@ -188,7 +192,8 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
         double blockSize = state.blockSize / guiScale;
         double zoomStep = Math.log(state.blockSize) / Math.log(2.0);
         for (LayerRenderer renderer : NavigatorApi.getActiveRenderersByPriority(MOD)) {
-            if (!(renderer instanceof UniversalLayerRenderer universal) || universal.hasMapMarker()) {
+            if (!(renderer instanceof UniversalLayerRenderer universal) || universal.hasMapMarker()
+                || universal.journeyMapV6OverlaysReplaceRenderSteps()) {
                 continue;
             }
             for (UniversalRenderStep<?> step : universal.getRenderSteps()) {
@@ -338,6 +343,7 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
             }
             for (Object candidate : candidates) {
                 if (!(candidate instanceof Displayable displayable)) continue;
+                if (displayable instanceof Overlay overlay) attachInteraction(overlay, renderer, step, null);
                 overlays.add(displayable);
             }
             showOverlays(overlays);
@@ -398,20 +404,28 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
             .setActiveUIs(Context.UI.Fullscreen);
 
         List<String> tooltip = marker.getTooltip();
-        if (tooltip == null && step instanceof UniversalInteractableStep<?>interactableStep) {
+        if (tooltip == null && step instanceof UniversalLocationInteractableStep<?>interactableStep) {
             tooltip = new ArrayList<>();
             interactableStep.getTooltip(tooltip);
         }
 
-        if (renderer instanceof UniversalInteractableRenderer interactableRenderer
-            && step instanceof UniversalInteractableStep<?>interactableStep) {
-            MarkerListener listener = overlay.getOverlayListener() instanceof MarkerListener markerListener
-                ? markerListener
-                : new MarkerListener(interactableRenderer, interactableStep);
-            listener.setTooltip(tooltip);
-            overlay.setOverlayListener(listener);
-        }
+        attachInteraction(overlay, renderer, step, tooltip);
         return overlay;
+    }
+
+    private void attachInteraction(Overlay overlay, UniversalLayerRenderer renderer, UniversalRenderStep<?> step,
+        @Nullable List<String> tooltip) {
+        if (overlay.getOverlayListener() != null
+            || !(renderer instanceof UniversalInteractableRenderer interactableRenderer)
+            || !(step instanceof UniversalLocationInteractableStep<?>interactableStep)) return;
+
+        if (tooltip == null) {
+            tooltip = new ArrayList<>();
+            interactableStep.getTooltip(tooltip);
+        }
+        OverlayListener listener = new OverlayListener(overlay, interactableRenderer, interactableStep);
+        listener.setTooltip(tooltip);
+        overlay.setOverlayListener(listener);
     }
 
     private int toJourneyMapZoom(int zoomStep) {
@@ -431,14 +445,14 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
     private void handleMarkerActionKey() {
         int keyCode = NavigatorApi.ACTION_KEY.getKeyCode();
         boolean down = keyCode >= 0 && keyCode < 256 && Keyboard.isKeyDown(keyCode);
-        if (down && !actionKeyDown && hoveredMarker != null) {
-            hoveredMarker.renderer.onRenderStepKeyPressed(hoveredMarker.step, keyCode);
+        if (down && !actionKeyDown && hoveredOverlay != null) {
+            hoveredOverlay.renderer.onRenderStepKeyPressed(hoveredOverlay.step, keyCode);
         }
         actionKeyDown = down;
     }
 
     private void removeOverlays(UniversalLayerRenderer renderer) {
-        if (hoveredMarker != null && hoveredMarker.renderer == renderer) clearHoveredMarker();
+        if (hoveredOverlay != null && hoveredOverlay.renderer == renderer) clearHoveredOverlay();
         Map<ILocationProvider, List<Displayable>> shown = overlays.remove(renderer);
         if (shown != null) shown.values()
             .forEach(this::removeOverlays);
@@ -447,8 +461,8 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
     private void removeOverlays(@Nullable Collection<Displayable> displayables) {
         if (displayables == null) return;
         for (Displayable displayable : displayables) {
-            if (displayable instanceof MarkerOverlay marker && marker.getOverlayListener() == hoveredMarker) {
-                clearHoveredMarker();
+            if (displayable instanceof Overlay overlay && overlay.getOverlayListener() == hoveredOverlay) {
+                clearHoveredOverlay();
             }
             api.remove(displayable);
         }
@@ -461,20 +475,23 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
                     .forEach(this::removeOverlays));
         overlays.clear();
         overlayRefreshVersions.clear();
-        clearHoveredMarker();
+        clearHoveredOverlay();
     }
 
-    private void clearHoveredMarker() {
-        hoveredMarker = null;
+    private void clearHoveredOverlay() {
+        if (hoveredOverlay != null) hoveredOverlay.clearHover();
     }
 
-    private final class MarkerListener implements IOverlayListener {
+    private final class OverlayListener implements IOverlayListener {
 
+        private final Overlay overlay;
         private final UniversalInteractableRenderer renderer;
-        private final UniversalInteractableStep<?> step;
+        private final UniversalLocationInteractableStep<?> step;
         private List<String> tooltip = new ArrayList<>();
 
-        private MarkerListener(UniversalInteractableRenderer renderer, UniversalInteractableStep<?> step) {
+        private OverlayListener(Overlay overlay, UniversalInteractableRenderer renderer,
+            UniversalLocationInteractableStep<?> step) {
+            this.overlay = overlay;
             this.renderer = renderer;
             this.step = step;
         }
@@ -486,7 +503,7 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
 
         @Override
         public void onMouseMove(UIState mapState, Point2D.Double mousePosition, BlockPos blockPosition) {
-            hoveredMarker = this;
+            hoveredOverlay = this;
         }
 
         @Override
@@ -498,6 +515,10 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
         public boolean onMouseClick(UIState mapState, Point2D.Double mousePosition, BlockPos blockPosition, int button,
             boolean doubleClick) {
             if (button != 0) return true;
+            if (!contains(blockPosition, (int) mousePosition.x, (int) mousePosition.y)) {
+                clearHover();
+                return true;
+            }
 
             boolean handled = renderer.onRenderStepClick(
                 step,
@@ -510,12 +531,55 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
         }
 
         private void clearHover() {
-            if (hoveredMarker == this) clearHoveredMarker();
+            renderer.clearRenderStepHover(step);
+            if (hoveredOverlay == this) hoveredOverlay = null;
         }
 
         private void setTooltip(@Nullable List<String> tooltip) {
             this.tooltip = tooltip == null ? new ArrayList<>() : new ArrayList<>(tooltip);
         }
+
+        private boolean contains(BlockPos position, int mouseX, int mouseY) {
+            if (overlay instanceof MarkerOverlay marker) {
+                return JourneyMapV6Plugin.this.contains(marker, mouseX, mouseY);
+            }
+            if (overlay instanceof PolygonOverlay polygon) {
+                if (!JourneyMapV6Plugin.contains(polygon.getOuterArea(), position)) return false;
+                return polygon.getHoles() == null || polygon.getHoles()
+                    .stream()
+                    .noneMatch(hole -> JourneyMapV6Plugin.contains(hole, position));
+            }
+            return true;
+        }
+    }
+
+    private boolean contains(MarkerOverlay marker, int mouseX, int mouseY) {
+        Minecraft minecraft = fullscreen.getMinecraft();
+        int guiScale = new ScaledResolution(minecraft, minecraft.displayWidth, minecraft.displayHeight)
+            .getScaleFactor();
+        UIState state = fullscreen.getUiState();
+        Point2D.Double position = getBlockPixel(
+            marker.getPoint()
+                .getX(),
+            marker.getPoint()
+                .getZ());
+        double centerX = position == null ? state.displayBounds.getCenterX() / guiScale + (marker.getPoint()
+            .getX() - fullscreen.getCenterBlockX(true)) * state.blockSize / guiScale : position.x / guiScale;
+        double centerY = position == null ? state.displayBounds.getCenterY() / guiScale + (marker.getPoint()
+            .getZ() - fullscreen.getCenterBlockZ(true)) * state.blockSize / guiScale : position.y / guiScale;
+        MapImage icon = marker.getIcon();
+        centerX += (int) state.blockSize / 2.0 / guiScale;
+        centerY += (int) state.blockSize / 2.0 / guiScale;
+        return mouseX >= centerX - icon.getAnchorX() / guiScale
+            && mouseX < centerX + (icon.getDisplayWidth() - icon.getAnchorX()) / guiScale
+            && mouseY >= centerY - icon.getAnchorY() / guiScale
+            && mouseY < centerY + (icon.getDisplayHeight() - icon.getAnchorY()) / guiScale;
+    }
+
+    private static boolean contains(MapPolygon mapPolygon, BlockPos position) {
+        Polygon polygon = new Polygon();
+        for (BlockPos point : mapPolygon.getPoints()) polygon.addPoint(point.getX(), point.getZ());
+        return polygon.contains(position.getX() + 0.5, position.getZ() + 0.5);
     }
 
     private void recache(int centerX, int centerZ, int width, int height) {
@@ -538,12 +602,16 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
     }
 
     private void drawTooltip(FullscreenRenderEvent event) {
-        if (hoveredMarker != null) {
-            if (!hoveredMarker.tooltip.isEmpty()) {
+        if (hoveredOverlay != null
+            && !hoveredOverlay.contains(getMouseBlock(event), event.getMouseX(), event.getMouseY())) {
+            clearHoveredOverlay();
+        }
+        if (hoveredOverlay != null) {
+            if (!hoveredOverlay.tooltip.isEmpty()) {
                 DrawUtils.drawSimpleTooltip(
                     event.getFullscreen()
                         .getScreen(),
-                    hoveredMarker.tooltip,
+                    hoveredOverlay.tooltip,
                     event.getMouseX() + 16,
                     event.getMouseY() - 12,
                     0xFFFFFFFF,
@@ -580,6 +648,20 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
             }
             return;
         }
+    }
+
+    private BlockPos getMouseBlock(FullscreenRenderEvent event) {
+        Minecraft minecraft = event.getFullscreen()
+            .getMinecraft();
+        int guiScale = new ScaledResolution(minecraft, minecraft.displayWidth, minecraft.displayHeight)
+            .getScaleFactor();
+        UIState state = event.getFullscreen()
+            .getUiState();
+        double x = event.getFullscreen()
+            .getCenterBlockX(true) + (event.getMouseX() * guiScale - minecraft.displayWidth / 2.0) / state.blockSize;
+        double z = event.getFullscreen()
+            .getCenterBlockZ(true) + (event.getMouseY() * guiScale - minecraft.displayHeight / 2.0) / state.blockSize;
+        return new BlockPos(x, 0, z);
     }
 
     private void drawSearchBar(FullscreenRenderEvent event) {
@@ -622,14 +704,20 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
         timeLastClick = now;
 
         BlockPos location = event.getLocation();
-        if (hoveredMarker != null && hoveredMarker.renderer
-            .onRenderStepClick(hoveredMarker.step, doubleClick, mouseX, mouseY, location.getX(), location.getZ())) {
+        if (hoveredOverlay != null && !hoveredOverlay.contains(location, mouseX, mouseY)) clearHoveredOverlay();
+        if (hoveredOverlay != null && hoveredOverlay.renderer
+            .onRenderStepClick(hoveredOverlay.step, doubleClick, mouseX, mouseY, location.getX(), location.getZ())) {
             event.cancel();
             return;
         }
 
         for (LayerRenderer renderer : NavigatorApi.getActiveRenderersFor(MOD)) {
-            if (renderer instanceof UniversalLayerRenderer universal && universal.hasJourneyMapV6Overlays()) continue;
+            if (hoveredOverlay != null && renderer instanceof UniversalLayerRenderer universal
+                && universal.hasJourneyMapV6Overlays()) continue;
+            if (renderer instanceof UniversalInteractableRenderer nativeInteractable
+                && nativeInteractable.hasJourneyMapV6Overlays()) {
+                nativeInteractable.clearRenderStepHover();
+            }
             if (renderer instanceof InteractableLayer interactable
                 && interactable.onMapClick(doubleClick, mouseX, mouseY, location.getX(), location.getZ())) {
                 event.cancel();

--- a/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
+++ b/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
@@ -67,6 +67,7 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
 
     private final Map<UniversalLayerRenderer, Map<ILocationProvider, List<Displayable>>> overlays = new IdentityHashMap<>();
     private final Map<LayerManager, Long> overlayRefreshVersions = new IdentityHashMap<>();
+    private final Map<MarkerOverlay, MapMarker> markerProperties = new IdentityHashMap<>();
     private @Nullable OverlayListener hoveredOverlay;
     private boolean actionKeyDown;
     private boolean fullscreenActive;
@@ -79,6 +80,7 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
     private long timeLastClick;
     private int searchScreenWidth = -1;
     private int searchScreenHeight = -1;
+    private int lastMarkerZoom = Integer.MIN_VALUE;
 
     @Override
     public String getModId() {
@@ -126,6 +128,7 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
         if (event.uiState.ui != Context.UI.Fullscreen || event.uiState.active == fullscreenActive) return;
 
         fullscreenActive = event.uiState.active;
+        lastMarkerZoom = Integer.MIN_VALUE;
         for (LayerManager manager : NavigatorApi.getEnabledLayers(MOD)) {
             if (fullscreenActive) {
                 manager.onGuiOpened(MOD);
@@ -135,6 +138,7 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
             }
         }
         if (!fullscreenActive) {
+            resetMarkerScales();
             fullscreen = null;
             searchBar = null;
         }
@@ -157,6 +161,10 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
         fullscreen = event.getFullscreen();
         UIState state = fullscreen.getUiState();
         if (!state.active || state.blockBounds == null || state.displayBounds == null || state.blockSize <= 0) return;
+        if (state.zoom != lastMarkerZoom) {
+            updateMarkerScales(state);
+            lastMarkerZoom = state.zoom;
+        }
 
         int centerX = (int) Math.round(fullscreen.getCenterBlockX(true));
         int centerZ = (int) Math.round(fullscreen.getCenterBlockZ(true));
@@ -375,6 +383,10 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
         if (!marker.isLabelOnMinimap()) overlay.getTextProperties()
             .setActiveUIs(Context.UI.Fullscreen);
 
+        markerProperties.put(overlay, marker);
+        if (fullscreen != null && fullscreen.getUiState().active)
+            updateMarkerScale(overlay, marker, fullscreen.getUiState());
+
         List<String> tooltip = marker.getTooltip();
         if (tooltip == null && step instanceof UniversalLocationInteractableStep<?>interactableStep) {
             tooltip = new ArrayList<>();
@@ -405,6 +417,41 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
 
     private int toJourneyMapZoom(int zoomStep) {
         return (int) Math.max(UIState.FULLSCREEN_ZOOM_MIN, Math.min(UIState.ZOOM_IN_MAX, 512 * Math.pow(2, zoomStep)));
+    }
+
+    private void updateMarkerScales(UIState state) {
+        markerProperties.forEach((overlay, marker) -> updateMarkerScale(overlay, marker, state));
+    }
+
+    private void updateMarkerScale(MarkerOverlay overlay, MapMarker marker, UIState state) {
+        double zoomStep = Math.log(state.blockSize) / Math.log(2.0);
+        applyMarkerScale(overlay, marker, marker.getDisplayZoomScale(zoomStep), marker.getLabelZoomScale(zoomStep));
+    }
+
+    private void resetMarkerScales() {
+        markerProperties.forEach((overlay, marker) -> applyMarkerScale(overlay, marker, 1, 1));
+    }
+
+    private void applyMarkerScale(MarkerOverlay overlay, MapMarker marker, double displayScale, double labelScale) {
+        MapImage image = overlay.getIcon();
+        double width = marker.getDisplayWidth() * displayScale;
+        double height = marker.getDisplayHeight() * displayScale;
+        float textScale = (float) (marker.getLabelScale() * labelScale);
+        int labelOffset = (int) Math.round(marker.getLabelOffsetY() * displayScale);
+        if (image.getDisplayWidth() == width && image.getDisplayHeight() == height
+            && overlay.getTextProperties()
+                .getScale() == textScale
+            && overlay.getTextProperties()
+                .getOffsetY() == labelOffset)
+            return;
+
+        image.setDisplayWidth(width)
+            .setDisplayHeight(height)
+            .centerAnchors();
+        overlay.getTextProperties()
+            .setScale(textScale)
+            .setOffsetY(labelOffset);
+        overlay.flagForRerender();
     }
 
     private void showOverlays(Collection<Displayable> displayables) {
@@ -439,6 +486,7 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
             if (displayable instanceof Overlay overlay && overlay.getOverlayListener() == hoveredOverlay) {
                 clearHoveredOverlay();
             }
+            if (displayable instanceof MarkerOverlay marker) markerProperties.remove(marker);
             api.remove(displayable);
         }
     }
@@ -450,6 +498,7 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
                     .forEach(this::removeOverlays));
         overlays.clear();
         overlayRefreshVersions.clear();
+        markerProperties.clear();
         clearHoveredOverlay();
     }
 

--- a/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
+++ b/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
@@ -126,6 +126,10 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
         return searchBar != null && searchBar.getVisible() && searchBar.isFocused();
     }
 
+    public static void onChatOpened() {
+        if (searchBar != null) searchBar.setFocused(false);
+    }
+
     public static boolean onSearchMouseClicked(int mouseX, int mouseY, int button) {
         if (searchBar == null || !searchBar.getVisible()) return false;
 
@@ -642,8 +646,8 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
             marker.getPoint()
                 .getZ());
         MapImage icon = marker.getIcon();
-        double centerX = position.x + (int) state.blockSize / 2.0;
-        double centerY = position.y + (int) state.blockSize / 2.0;
+        double centerX = position.x + state.blockSize / 2.0;
+        double centerY = position.y + state.blockSize / 2.0;
         return mouseX >= centerX - icon.getAnchorX() && mouseX < centerX + icon.getDisplayWidth() - icon.getAnchorX()
             && mouseY >= centerY - icon.getAnchorY()
             && mouseY < centerY + icon.getDisplayHeight() - icon.getAnchorY();

--- a/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
+++ b/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
@@ -114,8 +114,20 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
         return api;
     }
 
-    public static void centerOn(int blockX, int blockZ) {
+    public static void centerOn(int blockX, int blockZ, int zoom) {
         if (fullscreen != null && fullscreen.getUiState().active) {
+            if (zoom >= 0) {
+                int targetZoom = toJourneyMapZoom(zoom);
+                int currentZoom;
+                while ((currentZoom = fullscreen.getUiState().zoom) < targetZoom) {
+                    fullscreen.zoomIn();
+                    if (fullscreen.getUiState().zoom == currentZoom) break;
+                }
+                while ((currentZoom = fullscreen.getUiState().zoom) > targetZoom) {
+                    fullscreen.zoomOut();
+                    if (fullscreen.getUiState().zoom == currentZoom) break;
+                }
+            }
             fullscreen.centerOn(blockX, blockZ);
         }
     }
@@ -492,7 +504,7 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
         overlay.setOverlayListener(listener);
     }
 
-    private int toJourneyMapZoom(int zoomStep) {
+    private static int toJourneyMapZoom(int zoomStep) {
         return (int) Math.max(UIState.FULLSCREEN_ZOOM_MIN, Math.min(UIState.ZOOM_IN_MAX, 512 * Math.pow(2, zoomStep)));
     }
 
@@ -782,14 +794,21 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
     private void onClick(FullscreenMapEvent.ClickEvent event) {
         if (event.getStage() != FullscreenMapEvent.Stage.PRE || event.getButton() != 0) return;
 
-        int mouseX = (int) event.getMouseX();
-        int mouseY = (int) event.getMouseY();
+        int framebufferMouseX = (int) event.getMouseX();
+        int framebufferMouseY = (int) event.getMouseY();
+        Minecraft minecraft = fullscreen.getMinecraft();
+        int guiScale = new ScaledResolution(minecraft, minecraft.displayWidth, minecraft.displayHeight)
+            .getScaleFactor();
+        int mouseX = framebufferMouseX / guiScale;
+        int mouseY = framebufferMouseY / guiScale;
         long now = System.currentTimeMillis();
         boolean doubleClick = now - timeLastClick < 200L;
         timeLastClick = now;
 
         BlockPos location = event.getLocation();
-        if (hoveredOverlay != null && !hoveredOverlay.contains(mouseX, mouseY)) clearHoveredOverlay();
+        if (hoveredOverlay != null && !hoveredOverlay.contains(framebufferMouseX, framebufferMouseY)) {
+            clearHoveredOverlay();
+        }
         if (hoveredOverlay != null && hoveredOverlay.renderer
             .onRenderStepClick(hoveredOverlay.step, doubleClick, mouseX, mouseY, location.getX(), location.getZ())) {
             event.cancel();

--- a/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
+++ b/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
@@ -506,7 +506,7 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
             String label = marker.getLabel();
             if (Objects.equals(label, overlay.getLabel())) return;
             overlay.setLabel(label);
-            overlay.flagForRerender();
+            showOverlays(Collections.singleton(overlay));
         });
     }
 

--- a/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
+++ b/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
@@ -1,11 +1,23 @@
 package com.gtnewhorizons.navigator.internal.journeymap.v6;
 
+import java.awt.geom.Point2D;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Nullable;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.ScaledResolution;
+
+import org.lwjgl.input.Keyboard;
 
 import com.gtnewhorizons.navigator.Navigator;
 import com.gtnewhorizons.navigator.api.NavigatorApi;
@@ -14,18 +26,30 @@ import com.gtnewhorizons.navigator.api.model.buttons.ButtonManager;
 import com.gtnewhorizons.navigator.api.model.layers.InteractableLayer;
 import com.gtnewhorizons.navigator.api.model.layers.LayerManager;
 import com.gtnewhorizons.navigator.api.model.layers.LayerRenderer;
+import com.gtnewhorizons.navigator.api.model.layers.UniversalInteractableRenderer;
 import com.gtnewhorizons.navigator.api.model.layers.UniversalLayerRenderer;
+import com.gtnewhorizons.navigator.api.model.locations.ILocationProvider;
+import com.gtnewhorizons.navigator.api.model.markers.MapMarker;
+import com.gtnewhorizons.navigator.api.model.steps.UniversalInteractableStep;
 import com.gtnewhorizons.navigator.api.model.steps.UniversalRenderStep;
 import com.gtnewhorizons.navigator.api.util.DrawUtils;
+import com.gtnewhorizons.navigator.internal.SearchBar;
 
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.TickEvent;
 import journeymap.api.v2.client.IClientAPI;
 import journeymap.api.v2.client.IClientPlugin;
+import journeymap.api.v2.client.display.Displayable;
+import journeymap.api.v2.client.display.IOverlayListener;
+import journeymap.api.v2.client.display.MarkerOverlay;
 import journeymap.api.v2.client.event.DisplayUpdateEvent;
 import journeymap.api.v2.client.event.FullscreenDisplayEvent;
 import journeymap.api.v2.client.event.FullscreenMapEvent;
 import journeymap.api.v2.client.event.FullscreenRenderEvent;
 import journeymap.api.v2.client.fullscreen.IFullscreen;
 import journeymap.api.v2.client.fullscreen.IThemeButton;
+import journeymap.api.v2.client.model.MapImage;
 import journeymap.api.v2.client.util.UIState;
 import journeymap.api.v2.common.Context;
 import journeymap.api.v2.common.JourneyMapPlugin;
@@ -40,18 +64,29 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
 
     private static IClientAPI api;
     private static IFullscreen fullscreen;
+    private static @Nullable SearchBar searchBar;
+    private static @Nullable Object mapRenderer;
+    private static @Nullable Method getBlockPixelInGrid;
+    private static @Nullable Method committedDragOffsetX;
+    private static @Nullable Method committedDragOffsetZ;
+    private static boolean mapRendererLookupFailed;
 
+    private final Map<UniversalLayerRenderer, Map<ILocationProvider, List<Displayable>>> overlays = new IdentityHashMap<>();
+    private final Map<LayerManager, Long> overlayRefreshVersions = new IdentityHashMap<>();
+    private @Nullable MarkerListener hoveredMarker;
+    private boolean actionKeyDown;
     private boolean fullscreenActive;
+    private long lastOverlayUpdate;
     private long lastRecache;
     private int oldCenterX = Integer.MIN_VALUE;
     private int oldCenterZ = Integer.MIN_VALUE;
     private int oldWidth = -1;
     private int oldHeight = -1;
     private long timeLastClick;
-    private int oldMouseX;
-    private int oldMouseY;
     private ButtonManager lastPressedButton;
     private long lastButtonPress;
+    private int searchScreenWidth = -1;
+    private int searchScreenHeight = -1;
 
     @Override
     public String getModId() {
@@ -65,6 +100,9 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
         FullscreenEventRegistry.FULLSCREEN_RENDER_EVENT.subscribe(Navigator.MODID, this::onRender);
         FullscreenEventRegistry.FULLSCREEN_MAP_CLICK_EVENT.subscribe(Navigator.MODID, this::onClick);
         FullscreenEventRegistry.ADDON_BUTTON_DISPLAY_EVENT.subscribe(Navigator.MODID, this::onButtons);
+        FMLCommonHandler.instance()
+            .bus()
+            .register(this);
     }
 
     public static @Nullable IClientAPI getApi() {
@@ -75,6 +113,21 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
         if (fullscreen != null && fullscreen.getUiState().active) {
             fullscreen.centerOn(blockX, blockZ);
         }
+    }
+
+    public static boolean onSearchKeyTyped(char typedChar, int keyCode) {
+        return searchBar != null && searchBar.getVisible() && searchBar.textboxKeyTyped(typedChar, keyCode);
+    }
+
+    public static boolean isSearchFocused() {
+        return searchBar != null && searchBar.getVisible() && searchBar.isFocused();
+    }
+
+    public static boolean onSearchMouseClicked(int mouseX, int mouseY, int button) {
+        if (searchBar == null || !searchBar.getVisible()) return false;
+
+        searchBar.mouseClicked(mouseX, mouseY, button);
+        return searchBar.isHovered(mouseX, mouseY);
     }
 
     private void onDisplayUpdate(DisplayUpdateEvent event) {
@@ -89,7 +142,10 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
                 manager.onGuiClosed(MOD);
             }
         }
-        if (!fullscreenActive) fullscreen = null;
+        if (!fullscreenActive) {
+            fullscreen = null;
+            searchBar = null;
+        }
     }
 
     private void onButtons(FullscreenDisplayEvent.AddonButtonDisplayEvent event) {
@@ -130,21 +186,336 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
         int guiScale = new ScaledResolution(minecraft, minecraft.displayWidth, minecraft.displayHeight)
             .getScaleFactor();
         double blockSize = state.blockSize / guiScale;
-        double mapCenterX = fullscreen.getCenterBlockX(true);
-        double mapCenterZ = fullscreen.getCenterBlockZ(true);
         double zoomStep = Math.log(state.blockSize) / Math.log(2.0);
         for (LayerRenderer renderer : NavigatorApi.getActiveRenderersByPriority(MOD)) {
-            if (!(renderer instanceof UniversalLayerRenderer)) continue;
-            for (UniversalRenderStep<?> step : ((UniversalLayerRenderer) renderer).getRenderSteps()) {
-                double x = state.displayBounds.getCenterX() / guiScale + (step.getLocation()
-                    .getBlockX() - mapCenterX) * blockSize;
-                double y = state.displayBounds.getCenterY() / guiScale + (step.getLocation()
-                    .getBlockZ() - mapCenterZ) * blockSize;
-                step.drawJourneyMap(x, y, 1.0F / guiScale, zoomStep, blockSize, 1.0, 0.0);
+            if (!(renderer instanceof UniversalLayerRenderer universal) || universal.hasMapMarker()) {
+                continue;
+            }
+            for (UniversalRenderStep<?> step : universal.getRenderSteps()) {
+                Point2D.Double pixel = getBlockPixel(
+                    step.getLocation()
+                        .getBlockX(),
+                    step.getLocation()
+                        .getBlockZ());
+                double x;
+                double y;
+                if (pixel != null) {
+                    x = pixel.x / guiScale;
+                    y = pixel.y / guiScale;
+                } else {
+                    x = state.displayBounds.getCenterX() / guiScale + (step.getLocation()
+                        .getBlockX() - fullscreen.getCenterBlockX(true)) * blockSize;
+                    y = state.displayBounds.getCenterY() / guiScale + (step.getLocation()
+                        .getBlockZ() - fullscreen.getCenterBlockZ(true)) * blockSize;
+                }
+                step.drawJourneyMap(x, y, 1.0F / guiScale, zoomStep, blockSize, 1.0 / guiScale, 0.0);
             }
         }
 
+        drawSearchBar(event);
         drawTooltip(event);
+    }
+
+    private @Nullable Point2D.Double getBlockPixel(double blockX, double blockZ) {
+        if (mapRendererLookupFailed) return null;
+
+        try {
+            if (mapRenderer == null) {
+                Field field = fullscreen.getClass()
+                    .getDeclaredField("mapRenderer");
+                field.setAccessible(true);
+                mapRenderer = field.get(null);
+                Class<?> rendererClass = mapRenderer.getClass();
+                getBlockPixelInGrid = rendererClass.getMethod("getBlockPixelInGrid", double.class, double.class);
+                committedDragOffsetX = rendererClass.getMethod("committedDragOffsetX", double.class);
+                committedDragOffsetZ = rendererClass.getMethod("committedDragOffsetZ", double.class);
+            }
+
+            Point2D.Double pixel = (Point2D.Double) getBlockPixelInGrid.invoke(mapRenderer, blockX, blockZ);
+            double dragX = fullscreen.getCenterBlockX(false) - fullscreen.getCenterBlockX(true);
+            double dragZ = fullscreen.getCenterBlockZ(false) - fullscreen.getCenterBlockZ(true);
+            if (dragX != 0 || dragZ != 0) {
+                double blockSize = fullscreen.getUiState().blockSize;
+                pixel.x += (double) committedDragOffsetX.invoke(mapRenderer, dragX) * blockSize;
+                pixel.y += (double) committedDragOffsetZ.invoke(mapRenderer, dragZ) * blockSize;
+            }
+            return pixel;
+        } catch (Exception e) {
+            mapRendererLookupFailed = true;
+            Navigator.LOG.warn("Could not use JourneyMap 6's block-to-pixel conversion", e);
+            return null;
+        }
+    }
+
+    @SubscribeEvent
+    public void onClientTick(TickEvent.ClientTickEvent event) {
+        if (event.phase != TickEvent.Phase.END) return;
+
+        handleMarkerActionKey();
+        if (searchBar != null && searchBar.getVisible()) searchBar.updateCursorCounter();
+
+        // Navigator caches locations by viewport; poll until that cache can publish change events.
+        if (System.currentTimeMillis() - lastOverlayUpdate < 250L) return;
+
+        lastOverlayUpdate = System.currentTimeMillis();
+        Minecraft minecraft = Minecraft.getMinecraft();
+        if (minecraft.thePlayer == null || minecraft.theWorld == null) {
+            removeAllOverlays();
+            return;
+        }
+
+        UIState state = getActiveMapState();
+        for (LayerManager manager : NavigatorApi.getEnabledLayers(MOD)) {
+            LayerRenderer layer = manager.getLayerRenderer(MOD);
+            if (!(layer instanceof UniversalLayerRenderer renderer) || !renderer.hasJourneyMapV6Overlays()) {
+                continue;
+            }
+            if (!manager.isLayerActive()) {
+                removeOverlays(renderer);
+                continue;
+            }
+            if (state == null) continue;
+
+            long refreshVersion = manager.getRefreshVersion();
+            boolean refresh = overlayRefreshVersions.getOrDefault(manager, -1L) != refreshVersion;
+            int width = (int) Math.ceil(state.blockBounds.maxX - state.blockBounds.minX);
+            int height = (int) Math.ceil(state.blockBounds.maxZ - state.blockBounds.minZ);
+            if (state.ui == Context.UI.Fullscreen) {
+                manager.recacheFullscreenMap(state.mapCenter.getX(), state.mapCenter.getZ(), width, height);
+            } else {
+                manager.recacheMiniMap(state.mapCenter.getX(), state.mapCenter.getZ(), width, height);
+            }
+            syncOverlays(renderer, refresh);
+            overlayRefreshVersions.put(manager, refreshVersion);
+        }
+    }
+
+    private @Nullable UIState getActiveMapState() {
+        UIState state = api.getUIState(Context.UI.Fullscreen);
+        if (isUsable(state)) return state;
+
+        state = api.getUIState(Context.UI.Minimap);
+        return isUsable(state) ? state : null;
+    }
+
+    private boolean isUsable(@Nullable UIState state) {
+        return state != null && state.active && state.blockBounds != null && state.mapCenter != null;
+    }
+
+    private void syncOverlays(UniversalLayerRenderer renderer, boolean refresh) {
+        Map<ILocationProvider, List<Displayable>> shown = overlays
+            .computeIfAbsent(renderer, ignored -> new HashMap<>());
+        Set<ILocationProvider> visible = new HashSet<>();
+        for (UniversalRenderStep<?> step : renderer.getRenderSteps()) {
+            ILocationProvider location = step.getLocation();
+            visible.add(location);
+            if (renderer.hasMapMarker()) {
+                List<Displayable> current = shown.get(location);
+                if (current != null && !refresh) continue;
+
+                MarkerOverlay marker = createMarker(renderer, step);
+                if (marker == null) {
+                    removeOverlays(current);
+                    shown.put(location, new ArrayList<>());
+                } else {
+                    List<Displayable> updated = new ArrayList<>();
+                    updated.add(marker);
+                    showOverlays(updated);
+                    removeOverlays(current);
+                    shown.put(location, updated);
+                }
+                continue;
+            }
+
+            if (refresh) removeOverlays(shown.remove(location));
+            if (shown.containsKey(location)) continue;
+
+            List<Displayable> overlays = new ArrayList<>();
+            Collection<?> candidates = renderer.createJourneyMapV6Overlays(location);
+            if (candidates == null) {
+                shown.put(location, overlays);
+                continue;
+            }
+            for (Object candidate : candidates) {
+                if (!(candidate instanceof Displayable displayable)) continue;
+                overlays.add(displayable);
+            }
+            showOverlays(overlays);
+            shown.put(location, overlays);
+        }
+
+        if (refresh) {
+            shown.entrySet()
+                .removeIf(entry -> {
+                    if (visible.contains(entry.getKey())) return false;
+                    removeOverlays(entry.getValue());
+                    return true;
+                });
+        }
+    }
+
+    private @Nullable MarkerOverlay createMarker(UniversalLayerRenderer renderer, UniversalRenderStep<?> step) {
+        MapMarker marker = renderer.createMapMarker(step.getLocation());
+        if (marker == null) return null;
+
+        MapImage image;
+        if (marker.getImage() != null) {
+            image = new MapImage(marker.getImage());
+        } else if (marker.getImageLocation() != null) {
+            image = new MapImage(marker.getImageLocation(), marker.getTextureWidth(), marker.getTextureHeight());
+        } else {
+            return null;
+        }
+        image.setDisplayWidth(marker.getDisplayWidth())
+            .setDisplayHeight(marker.getDisplayHeight())
+            .centerAnchors()
+            .setBlur(false);
+
+        ILocationProvider location = step.getLocation();
+        BlockPos point = new BlockPos(
+            (int) Math.floor(location.getBlockX()),
+            64,
+            (int) Math.floor(location.getBlockZ()));
+        MarkerOverlay overlay = new MarkerOverlay(Navigator.MODID, point, image);
+        overlay.setDimension(location.getDimensionId())
+            .setOverlayGroupName(
+                location.getClass()
+                    .getName())
+            .setActiveUIs(Context.UI.Fullscreen, Context.UI.Minimap)
+            .setDisplayOrder(100 + renderer.getRenderPriority());
+
+        overlay.setLabel(marker.getLabel())
+            .setTitle(null);
+        int labelMinZoom = marker.getLabelMinZoom() == null ? UIState.FULLSCREEN_ZOOM_MIN
+            : toJourneyMapZoom(marker.getLabelMinZoom());
+        overlay.getTextProperties()
+            .setColor(marker.getLabelColor())
+            .setScale(marker.getLabelScale())
+            .setBackgroundOpacity(marker.getLabelBackgroundOpacity())
+            .setOffsetY(marker.getLabelOffsetY())
+            .setMinZoom(labelMinZoom);
+        if (!marker.isLabelOnMinimap()) overlay.getTextProperties()
+            .setActiveUIs(Context.UI.Fullscreen);
+
+        List<String> tooltip = marker.getTooltip();
+        if (tooltip == null && step instanceof UniversalInteractableStep<?>interactableStep) {
+            tooltip = new ArrayList<>();
+            interactableStep.getTooltip(tooltip);
+        }
+
+        if (renderer instanceof UniversalInteractableRenderer interactableRenderer
+            && step instanceof UniversalInteractableStep<?>interactableStep) {
+            MarkerListener listener = overlay.getOverlayListener() instanceof MarkerListener markerListener
+                ? markerListener
+                : new MarkerListener(interactableRenderer, interactableStep);
+            listener.setTooltip(tooltip);
+            overlay.setOverlayListener(listener);
+        }
+        return overlay;
+    }
+
+    private int toJourneyMapZoom(int zoomStep) {
+        return (int) Math.max(UIState.FULLSCREEN_ZOOM_MIN, Math.min(UIState.ZOOM_IN_MAX, 512 * Math.pow(2, zoomStep)));
+    }
+
+    private void showOverlays(Collection<Displayable> displayables) {
+        for (Displayable displayable : displayables) {
+            try {
+                api.show(displayable);
+            } catch (Exception e) {
+                Navigator.LOG.error("Could not show JourneyMap 6 overlay", e);
+            }
+        }
+    }
+
+    private void handleMarkerActionKey() {
+        int keyCode = NavigatorApi.ACTION_KEY.getKeyCode();
+        boolean down = keyCode >= 0 && keyCode < 256 && Keyboard.isKeyDown(keyCode);
+        if (down && !actionKeyDown && hoveredMarker != null) {
+            hoveredMarker.renderer.onRenderStepKeyPressed(hoveredMarker.step, keyCode);
+        }
+        actionKeyDown = down;
+    }
+
+    private void removeOverlays(UniversalLayerRenderer renderer) {
+        if (hoveredMarker != null && hoveredMarker.renderer == renderer) clearHoveredMarker();
+        Map<ILocationProvider, List<Displayable>> shown = overlays.remove(renderer);
+        if (shown != null) shown.values()
+            .forEach(this::removeOverlays);
+    }
+
+    private void removeOverlays(@Nullable Collection<Displayable> displayables) {
+        if (displayables == null) return;
+        for (Displayable displayable : displayables) {
+            if (displayable instanceof MarkerOverlay marker && marker.getOverlayListener() == hoveredMarker) {
+                clearHoveredMarker();
+            }
+            api.remove(displayable);
+        }
+    }
+
+    private void removeAllOverlays() {
+        overlays.values()
+            .forEach(
+                shown -> shown.values()
+                    .forEach(this::removeOverlays));
+        overlays.clear();
+        overlayRefreshVersions.clear();
+        clearHoveredMarker();
+    }
+
+    private void clearHoveredMarker() {
+        hoveredMarker = null;
+    }
+
+    private final class MarkerListener implements IOverlayListener {
+
+        private final UniversalInteractableRenderer renderer;
+        private final UniversalInteractableStep<?> step;
+        private List<String> tooltip = new ArrayList<>();
+
+        private MarkerListener(UniversalInteractableRenderer renderer, UniversalInteractableStep<?> step) {
+            this.renderer = renderer;
+            this.step = step;
+        }
+
+        @Override
+        public void onDeactivate(UIState mapState) {
+            clearHover();
+        }
+
+        @Override
+        public void onMouseMove(UIState mapState, Point2D.Double mousePosition, BlockPos blockPosition) {
+            hoveredMarker = this;
+        }
+
+        @Override
+        public void onMouseOut(UIState mapState, Point2D.Double mousePosition, BlockPos blockPosition) {
+            clearHover();
+        }
+
+        @Override
+        public boolean onMouseClick(UIState mapState, Point2D.Double mousePosition, BlockPos blockPosition, int button,
+            boolean doubleClick) {
+            if (button != 0) return true;
+
+            boolean handled = renderer.onRenderStepClick(
+                step,
+                doubleClick,
+                (int) mousePosition.x,
+                (int) mousePosition.y,
+                blockPosition.getX(),
+                blockPosition.getZ());
+            return !handled;
+        }
+
+        private void clearHover() {
+            if (hoveredMarker == this) clearHoveredMarker();
+        }
+
+        private void setTooltip(@Nullable List<String> tooltip) {
+            this.tooltip = tooltip == null ? new ArrayList<>() : new ArrayList<>(tooltip);
+        }
     }
 
     private void recache(int centerX, int centerZ, int width, int height) {
@@ -167,7 +538,22 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
     }
 
     private void drawTooltip(FullscreenRenderEvent event) {
+        if (hoveredMarker != null) {
+            if (!hoveredMarker.tooltip.isEmpty()) {
+                DrawUtils.drawSimpleTooltip(
+                    event.getFullscreen()
+                        .getScreen(),
+                    hoveredMarker.tooltip,
+                    event.getMouseX() + 16,
+                    event.getMouseY() - 12,
+                    0xFFFFFFFF,
+                    0x86000000);
+            }
+            return;
+        }
+
         for (LayerRenderer renderer : NavigatorApi.getActiveRenderersFor(MOD)) {
+            if (renderer instanceof UniversalLayerRenderer universal && universal.hasJourneyMapV6Overlays()) continue;
             if (!(renderer instanceof InteractableLayer interactable)) continue;
 
             interactable.onMouseMove(event.getMouseX(), event.getMouseY());
@@ -196,19 +582,54 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
         }
     }
 
+    private void drawSearchBar(FullscreenRenderEvent event) {
+        boolean visible = NavigatorApi.getEnabledLayers(MOD)
+            .stream()
+            .anyMatch(manager -> manager.isLayerActive() && manager.hasSearchField());
+        if (!visible) {
+            if (searchBar != null) searchBar.setVisible(false);
+            return;
+        }
+
+        int width = event.getFullscreen()
+            .getScreen().width;
+        int height = event.getFullscreen()
+            .getScreen().height;
+        if (searchBar == null || width != searchScreenWidth || height != searchScreenHeight) {
+            searchScreenWidth = width;
+            searchScreenHeight = height;
+            searchBar = new SearchBar(6, height - 51, Math.min(width / 2 - 50, 200) * 2 / 3, 16);
+            searchBar.setTextConsumer(
+                text -> NavigatorApi.getEnabledLayers(MOD)
+                    .forEach(manager -> {
+                        if (manager.isLayerActive() && manager.hasSearchField()) {
+                            manager.onSearch(text);
+                            manager.forceRefresh();
+                        }
+                    }));
+        }
+        searchBar.setVisible(true);
+        searchBar.drawTextBox();
+    }
+
     private void onClick(FullscreenMapEvent.ClickEvent event) {
         if (event.getStage() != FullscreenMapEvent.Stage.PRE || event.getButton() != 0) return;
 
         int mouseX = (int) event.getMouseX();
         int mouseY = (int) event.getMouseY();
         long now = System.currentTimeMillis();
-        boolean doubleClick = mouseX == oldMouseX && mouseY == oldMouseY && now - timeLastClick < 250L;
-        oldMouseX = mouseX;
-        oldMouseY = mouseY;
+        boolean doubleClick = now - timeLastClick < 200L;
         timeLastClick = now;
 
         BlockPos location = event.getLocation();
+        if (hoveredMarker != null && hoveredMarker.renderer
+            .onRenderStepClick(hoveredMarker.step, doubleClick, mouseX, mouseY, location.getX(), location.getZ())) {
+            event.cancel();
+            return;
+        }
+
         for (LayerRenderer renderer : NavigatorApi.getActiveRenderersFor(MOD)) {
+            if (renderer instanceof UniversalLayerRenderer universal && universal.hasJourneyMapV6Overlays()) continue;
             if (renderer instanceof InteractableLayer interactable
                 && interactable.onMapClick(doubleClick, mouseX, mouseY, location.getX(), location.getZ())) {
                 event.cancel();

--- a/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
+++ b/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
@@ -1,6 +1,5 @@
 package com.gtnewhorizons.navigator.internal.journeymap.v6;
 
-import java.awt.Polygon;
 import java.awt.geom.Point2D;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -45,7 +44,6 @@ import journeymap.api.v2.client.display.Displayable;
 import journeymap.api.v2.client.display.IOverlayListener;
 import journeymap.api.v2.client.display.MarkerOverlay;
 import journeymap.api.v2.client.display.Overlay;
-import journeymap.api.v2.client.display.PolygonOverlay;
 import journeymap.api.v2.client.event.DisplayUpdateEvent;
 import journeymap.api.v2.client.event.FullscreenDisplayEvent;
 import journeymap.api.v2.client.event.FullscreenMapEvent;
@@ -53,7 +51,6 @@ import journeymap.api.v2.client.event.FullscreenRenderEvent;
 import journeymap.api.v2.client.fullscreen.IFullscreen;
 import journeymap.api.v2.client.fullscreen.IThemeButton;
 import journeymap.api.v2.client.model.MapImage;
-import journeymap.api.v2.client.model.MapPolygon;
 import journeymap.api.v2.client.util.UIState;
 import journeymap.api.v2.common.Context;
 import journeymap.api.v2.common.JourneyMapPlugin;
@@ -87,8 +84,6 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
     private int oldWidth = -1;
     private int oldHeight = -1;
     private long timeLastClick;
-    private ButtonManager lastPressedButton;
-    private long lastButtonPress;
     private int searchScreenWidth = -1;
     private int searchScreenHeight = -1;
 
@@ -160,19 +155,9 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
                     manager.getButtonText(),
                     manager.getIcon(MOD, ""),
                     manager.isActive(),
-                    ignored -> toggleButton(manager));
+                    ignored -> manager.toggle());
             manager.setOnToggle(button::setToggled);
         }
-    }
-
-    private void toggleButton(ButtonManager manager) {
-        long now = System.nanoTime();
-        // JM 6.0.0-beta.1 adds addon buttons to the fullscreen twice and invokes both entries on one click.
-        if (manager == lastPressedButton && now - lastButtonPress < 50_000_000L) return;
-
-        lastPressedButton = manager;
-        lastButtonPress = now;
-        manager.toggle();
     }
 
     private void onRender(FullscreenRenderEvent event) {
@@ -423,7 +408,10 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
             tooltip = new ArrayList<>();
             interactableStep.getTooltip(tooltip);
         }
-        OverlayListener listener = new OverlayListener(overlay, interactableRenderer, interactableStep);
+        OverlayListener listener = new OverlayListener(
+            overlay instanceof MarkerOverlay marker ? marker : null,
+            interactableRenderer,
+            interactableStep);
         listener.setTooltip(tooltip);
         overlay.setOverlayListener(listener);
     }
@@ -484,14 +472,14 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
 
     private final class OverlayListener implements IOverlayListener {
 
-        private final Overlay overlay;
+        private final @Nullable MarkerOverlay marker;
         private final UniversalInteractableRenderer renderer;
         private final UniversalLocationInteractableStep<?> step;
         private List<String> tooltip = new ArrayList<>();
 
-        private OverlayListener(Overlay overlay, UniversalInteractableRenderer renderer,
+        private OverlayListener(@Nullable MarkerOverlay marker, UniversalInteractableRenderer renderer,
             UniversalLocationInteractableStep<?> step) {
-            this.overlay = overlay;
+            this.marker = marker;
             this.renderer = renderer;
             this.step = step;
         }
@@ -503,6 +491,11 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
 
         @Override
         public void onMouseMove(UIState mapState, Point2D.Double mousePosition, BlockPos blockPosition) {
+            if (!contains((int) mousePosition.x, (int) mousePosition.y)) {
+                clearHover();
+                return;
+            }
+            renderer.setRenderStepHover(step);
             hoveredOverlay = this;
         }
 
@@ -515,11 +508,10 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
         public boolean onMouseClick(UIState mapState, Point2D.Double mousePosition, BlockPos blockPosition, int button,
             boolean doubleClick) {
             if (button != 0) return true;
-            if (!contains(blockPosition, (int) mousePosition.x, (int) mousePosition.y)) {
+            if (!contains((int) mousePosition.x, (int) mousePosition.y)) {
                 clearHover();
                 return true;
             }
-
             boolean handled = renderer.onRenderStepClick(
                 step,
                 doubleClick,
@@ -539,47 +531,28 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
             this.tooltip = tooltip == null ? new ArrayList<>() : new ArrayList<>(tooltip);
         }
 
-        private boolean contains(BlockPos position, int mouseX, int mouseY) {
-            if (overlay instanceof MarkerOverlay marker) {
-                return JourneyMapV6Plugin.this.contains(marker, mouseX, mouseY);
-            }
-            if (overlay instanceof PolygonOverlay polygon) {
-                if (!JourneyMapV6Plugin.contains(polygon.getOuterArea(), position)) return false;
-                return polygon.getHoles() == null || polygon.getHoles()
-                    .stream()
-                    .noneMatch(hole -> JourneyMapV6Plugin.contains(hole, position));
-            }
-            return true;
+        private boolean contains(int mouseX, int mouseY) {
+            return marker == null || JourneyMapV6Plugin.this.contains(marker, mouseX, mouseY);
         }
     }
 
     private boolean contains(MarkerOverlay marker, int mouseX, int mouseY) {
-        Minecraft minecraft = fullscreen.getMinecraft();
-        int guiScale = new ScaledResolution(minecraft, minecraft.displayWidth, minecraft.displayHeight)
-            .getScaleFactor();
         UIState state = fullscreen.getUiState();
         Point2D.Double position = getBlockPixel(
             marker.getPoint()
                 .getX(),
             marker.getPoint()
                 .getZ());
-        double centerX = position == null ? state.displayBounds.getCenterX() / guiScale + (marker.getPoint()
-            .getX() - fullscreen.getCenterBlockX(true)) * state.blockSize / guiScale : position.x / guiScale;
-        double centerY = position == null ? state.displayBounds.getCenterY() / guiScale + (marker.getPoint()
-            .getZ() - fullscreen.getCenterBlockZ(true)) * state.blockSize / guiScale : position.y / guiScale;
+        double centerX = position == null ? state.displayBounds.getCenterX() + (marker.getPoint()
+            .getX() - fullscreen.getCenterBlockX(true)) * state.blockSize : position.x;
+        double centerY = position == null ? state.displayBounds.getCenterY() + (marker.getPoint()
+            .getZ() - fullscreen.getCenterBlockZ(true)) * state.blockSize : position.y;
         MapImage icon = marker.getIcon();
-        centerX += (int) state.blockSize / 2.0 / guiScale;
-        centerY += (int) state.blockSize / 2.0 / guiScale;
-        return mouseX >= centerX - icon.getAnchorX() / guiScale
-            && mouseX < centerX + (icon.getDisplayWidth() - icon.getAnchorX()) / guiScale
-            && mouseY >= centerY - icon.getAnchorY() / guiScale
-            && mouseY < centerY + (icon.getDisplayHeight() - icon.getAnchorY()) / guiScale;
-    }
-
-    private static boolean contains(MapPolygon mapPolygon, BlockPos position) {
-        Polygon polygon = new Polygon();
-        for (BlockPos point : mapPolygon.getPoints()) polygon.addPoint(point.getX(), point.getZ());
-        return polygon.contains(position.getX() + 0.5, position.getZ() + 0.5);
+        centerX += (int) state.blockSize / 2.0;
+        centerY += (int) state.blockSize / 2.0;
+        return mouseX >= centerX - icon.getAnchorX() && mouseX < centerX + icon.getDisplayWidth() - icon.getAnchorX()
+            && mouseY >= centerY - icon.getAnchorY()
+            && mouseY < centerY + icon.getDisplayHeight() - icon.getAnchorY();
     }
 
     private void recache(int centerX, int centerZ, int width, int height) {
@@ -602,10 +575,6 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
     }
 
     private void drawTooltip(FullscreenRenderEvent event) {
-        if (hoveredOverlay != null
-            && !hoveredOverlay.contains(getMouseBlock(event), event.getMouseX(), event.getMouseY())) {
-            clearHoveredOverlay();
-        }
         if (hoveredOverlay != null) {
             if (!hoveredOverlay.tooltip.isEmpty()) {
                 DrawUtils.drawSimpleTooltip(
@@ -616,6 +585,16 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
                     event.getMouseY() - 12,
                     0xFFFFFFFF,
                     0x86000000);
+            } else {
+                hoveredOverlay.renderer.drawCustomTooltip(
+                    event.getFullscreen()
+                        .getMinecraft().fontRenderer,
+                    event.getMouseX(),
+                    event.getMouseY(),
+                    event.getFullscreen()
+                        .getScreen().width,
+                    event.getFullscreen()
+                        .getScreen().height);
             }
             return;
         }
@@ -648,20 +627,6 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
             }
             return;
         }
-    }
-
-    private BlockPos getMouseBlock(FullscreenRenderEvent event) {
-        Minecraft minecraft = event.getFullscreen()
-            .getMinecraft();
-        int guiScale = new ScaledResolution(minecraft, minecraft.displayWidth, minecraft.displayHeight)
-            .getScaleFactor();
-        UIState state = event.getFullscreen()
-            .getUiState();
-        double x = event.getFullscreen()
-            .getCenterBlockX(true) + (event.getMouseX() * guiScale - minecraft.displayWidth / 2.0) / state.blockSize;
-        double z = event.getFullscreen()
-            .getCenterBlockZ(true) + (event.getMouseY() * guiScale - minecraft.displayHeight / 2.0) / state.blockSize;
-        return new BlockPos(x, 0, z);
     }
 
     private void drawSearchBar(FullscreenRenderEvent event) {
@@ -704,7 +669,7 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
         timeLastClick = now;
 
         BlockPos location = event.getLocation();
-        if (hoveredOverlay != null && !hoveredOverlay.contains(location, mouseX, mouseY)) clearHoveredOverlay();
+        if (hoveredOverlay != null && !hoveredOverlay.contains(mouseX, mouseY)) clearHoveredOverlay();
         if (hoveredOverlay != null && hoveredOverlay.renderer
             .onRenderStepClick(hoveredOverlay.step, doubleClick, mouseX, mouseY, location.getX(), location.getZ())) {
             event.cancel();

--- a/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
+++ b/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
@@ -1,8 +1,6 @@
 package com.gtnewhorizons.navigator.internal.journeymap.v6;
 
 import java.awt.geom.Point2D;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -66,11 +64,6 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
     private static IClientAPI api;
     private static IFullscreen fullscreen;
     private static @Nullable SearchBar searchBar;
-    private static @Nullable Object mapRenderer;
-    private static @Nullable Method getBlockPixelInGrid;
-    private static @Nullable Method committedDragOffsetX;
-    private static @Nullable Method committedDragOffsetZ;
-    private static boolean mapRendererLookupFailed;
 
     private final Map<UniversalLayerRenderer, Map<ILocationProvider, List<Displayable>>> overlays = new IdentityHashMap<>();
     private final Map<LayerManager, Long> overlayRefreshVersions = new IdentityHashMap<>();
@@ -187,18 +180,14 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
                         .getBlockX(),
                     step.getLocation()
                         .getBlockZ());
-                double x;
-                double y;
-                if (pixel != null) {
-                    x = pixel.x / guiScale;
-                    y = pixel.y / guiScale;
-                } else {
-                    x = state.displayBounds.getCenterX() / guiScale + (step.getLocation()
-                        .getBlockX() - fullscreen.getCenterBlockX(true)) * blockSize;
-                    y = state.displayBounds.getCenterY() / guiScale + (step.getLocation()
-                        .getBlockZ() - fullscreen.getCenterBlockZ(true)) * blockSize;
-                }
-                step.drawJourneyMap(x, y, 1.0F / guiScale, zoomStep, blockSize, 1.0 / guiScale, 0.0);
+                step.drawJourneyMap(
+                    pixel.x / guiScale,
+                    pixel.y / guiScale,
+                    1.0F / guiScale,
+                    zoomStep,
+                    blockSize,
+                    1.0 / guiScale,
+                    0.0);
             }
         }
 
@@ -206,35 +195,26 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
         drawTooltip(event);
     }
 
-    private @Nullable Point2D.Double getBlockPixel(double blockX, double blockZ) {
-        if (mapRendererLookupFailed) return null;
+    /** Mirrors JourneyMap's pixel-snapped grid position using public fullscreen state. */
+    private Point2D.Double getBlockPixel(double blockX, double blockZ) {
+        double blockSize = fullscreen.getUiState().blockSize;
+        double centerX = fullscreen.getCenterBlockX(false);
+        double centerZ = fullscreen.getCenterBlockZ(false);
+        Minecraft minecraft = fullscreen.getMinecraft();
+        double x = minecraft.displayWidth / 2 + (snapToScreenPixel(blockX, blockSize) - centerX) * blockSize;
+        double y = minecraft.displayHeight / 2 + (snapToScreenPixel(blockZ, blockSize) - centerZ) * blockSize;
 
-        try {
-            if (mapRenderer == null) {
-                Field field = fullscreen.getClass()
-                    .getDeclaredField("mapRenderer");
-                field.setAccessible(true);
-                mapRenderer = field.get(null);
-                Class<?> rendererClass = mapRenderer.getClass();
-                getBlockPixelInGrid = rendererClass.getMethod("getBlockPixelInGrid", double.class, double.class);
-                committedDragOffsetX = rendererClass.getMethod("committedDragOffsetX", double.class);
-                committedDragOffsetZ = rendererClass.getMethod("committedDragOffsetZ", double.class);
-            }
-
-            Point2D.Double pixel = (Point2D.Double) getBlockPixelInGrid.invoke(mapRenderer, blockX, blockZ);
-            double dragX = fullscreen.getCenterBlockX(false) - fullscreen.getCenterBlockX(true);
-            double dragZ = fullscreen.getCenterBlockZ(false) - fullscreen.getCenterBlockZ(true);
-            if (dragX != 0 || dragZ != 0) {
-                double blockSize = fullscreen.getUiState().blockSize;
-                pixel.x += (double) committedDragOffsetX.invoke(mapRenderer, dragX) * blockSize;
-                pixel.y += (double) committedDragOffsetZ.invoke(mapRenderer, dragZ) * blockSize;
-            }
-            return pixel;
-        } catch (Exception e) {
-            mapRendererLookupFailed = true;
-            Navigator.LOG.warn("Could not use JourneyMap 6's block-to-pixel conversion", e);
-            return null;
+        double dragX = centerX - fullscreen.getCenterBlockX(true);
+        double dragZ = centerZ - fullscreen.getCenterBlockZ(true);
+        if (dragX != 0 || dragZ != 0) {
+            x += (centerX - snapToScreenPixel(centerX - dragX, blockSize)) * blockSize;
+            y += (centerZ - snapToScreenPixel(centerZ - dragZ, blockSize)) * blockSize;
         }
+        return new Point2D.Double(x, y);
+    }
+
+    private static double snapToScreenPixel(double blockCoordinate, double blockSize) {
+        return Math.floor(blockCoordinate * blockSize) / blockSize;
     }
 
     @SubscribeEvent
@@ -514,19 +494,8 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
         @Override
         public boolean onMouseClick(UIState mapState, Point2D.Double mousePosition, BlockPos blockPosition, int button,
             boolean doubleClick) {
-            if (button != 0) return true;
-            if (!contains((int) mousePosition.x, (int) mousePosition.y)) {
-                clearHover();
-                return true;
-            }
-            boolean handled = renderer.onRenderStepClick(
-                step,
-                doubleClick,
-                (int) mousePosition.x,
-                (int) mousePosition.y,
-                blockPosition.getX(),
-                blockPosition.getZ());
-            return !handled;
+            // Fullscreen clicks are dispatched by the PRE map-click event before JourneyMap's own layers run.
+            return true;
         }
 
         private void clearHover() {
@@ -544,19 +513,17 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
     }
 
     private boolean contains(MarkerOverlay marker, int mouseX, int mouseY) {
+        if (fullscreen == null) return false;
+
         UIState state = fullscreen.getUiState();
         Point2D.Double position = getBlockPixel(
             marker.getPoint()
                 .getX(),
             marker.getPoint()
                 .getZ());
-        double centerX = position == null ? state.displayBounds.getCenterX() + (marker.getPoint()
-            .getX() - fullscreen.getCenterBlockX(true)) * state.blockSize : position.x;
-        double centerY = position == null ? state.displayBounds.getCenterY() + (marker.getPoint()
-            .getZ() - fullscreen.getCenterBlockZ(true)) * state.blockSize : position.y;
         MapImage icon = marker.getIcon();
-        centerX += (int) state.blockSize / 2.0;
-        centerY += (int) state.blockSize / 2.0;
+        double centerX = position.x + (int) state.blockSize / 2.0;
+        double centerY = position.y + (int) state.blockSize / 2.0;
         return mouseX >= centerX - icon.getAnchorX() && mouseX < centerX + icon.getDisplayWidth() - icon.getAnchorX()
             && mouseY >= centerY - icon.getAnchorY()
             && mouseY < centerY + icon.getDisplayHeight() - icon.getAnchorY();
@@ -606,33 +573,38 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
             return;
         }
 
+        List<InteractableLayer> interactables = new ArrayList<>();
+        List<String> tooltip = null;
         for (LayerRenderer renderer : NavigatorApi.getActiveRenderersFor(MOD)) {
             if (renderer instanceof UniversalLayerRenderer universal && universal.hasJourneyMapV6Overlays()) continue;
             if (!(renderer instanceof InteractableLayer interactable)) continue;
 
+            interactables.add(interactable);
             interactable.onMouseMove(event.getMouseX(), event.getMouseY());
-            List<String> tooltip = interactable.getTooltip();
-            if (!tooltip.isEmpty()) {
-                DrawUtils.drawSimpleTooltip(
-                    event.getFullscreen()
-                        .getScreen(),
-                    tooltip,
-                    event.getMouseX() + 16,
-                    event.getMouseY() - 12,
-                    0xFFFFFFFF,
-                    0x86000000);
-            } else {
-                interactable.drawCustomTooltip(
-                    event.getFullscreen()
-                        .getMinecraft().fontRenderer,
-                    event.getMouseX(),
-                    event.getMouseY(),
-                    event.getFullscreen()
-                        .getScreen().width,
-                    event.getFullscreen()
-                        .getScreen().height);
-            }
+            if (tooltip == null || tooltip.isEmpty()) tooltip = interactable.getTooltip();
+        }
+
+        if (tooltip != null && !tooltip.isEmpty()) {
+            DrawUtils.drawSimpleTooltip(
+                event.getFullscreen()
+                    .getScreen(),
+                tooltip,
+                event.getMouseX() + 16,
+                event.getMouseY() - 12,
+                0xFFFFFFFF,
+                0x86000000);
             return;
+        }
+        for (InteractableLayer interactable : interactables) {
+            interactable.drawCustomTooltip(
+                event.getFullscreen()
+                    .getMinecraft().fontRenderer,
+                event.getMouseX(),
+                event.getMouseY(),
+                event.getFullscreen()
+                    .getScreen().width,
+                event.getFullscreen()
+                    .getScreen().height);
         }
     }
 

--- a/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
+++ b/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.annotation.Nullable;
@@ -89,6 +90,7 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
     private int searchScreenWidth = -1;
     private int searchScreenHeight = -1;
     private int lastMarkerZoom = Integer.MIN_VALUE;
+    private long lastDynamicLabelUpdate;
 
     @Override
     public String getModId() {
@@ -257,6 +259,11 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
 
         UIState state = getActiveMapState();
         if (state == null) return;
+        long now = System.currentTimeMillis();
+        if (now - lastDynamicLabelUpdate >= 1000) {
+            updateDynamicMarkerLabels();
+            lastDynamicLabelUpdate = now;
+        }
         if (overlayViewportChanged(state)) {
             syncVisibleOverlays(state);
         } else {
@@ -491,6 +498,16 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
 
     private void updateMarkerScales(UIState state) {
         markerProperties.forEach((overlay, marker) -> updateMarkerScale(overlay, marker, state));
+    }
+
+    private void updateDynamicMarkerLabels() {
+        markerProperties.forEach((overlay, marker) -> {
+            if (!marker.hasDynamicLabel()) return;
+            String label = marker.getLabel();
+            if (Objects.equals(label, overlay.getLabel())) return;
+            overlay.setLabel(label);
+            overlay.flagForRerender();
+        });
     }
 
     private void updateMarkerScale(MarkerOverlay overlay, MapMarker marker, UIState state) {

--- a/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
+++ b/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
@@ -116,7 +116,7 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
 
     public static void centerOn(int blockX, int blockZ, int zoom) {
         if (fullscreen != null && fullscreen.getUiState().active) {
-            if (zoom >= 0) {
+            if (zoom != -1) {
                 int targetZoom = toJourneyMapZoom(zoom);
                 int currentZoom;
                 while ((currentZoom = fullscreen.getUiState().zoom) < targetZoom) {

--- a/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
+++ b/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
@@ -3,6 +3,7 @@ package com.gtnewhorizons.navigator.internal.journeymap.v6;
 import java.awt.geom.Point2D;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
@@ -19,6 +20,7 @@ import org.lwjgl.input.Keyboard;
 
 import com.gtnewhorizons.navigator.Navigator;
 import com.gtnewhorizons.navigator.api.NavigatorApi;
+import com.gtnewhorizons.navigator.api.event.LayerRefreshEvent;
 import com.gtnewhorizons.navigator.api.model.SupportedMods;
 import com.gtnewhorizons.navigator.api.model.buttons.ButtonManager;
 import com.gtnewhorizons.navigator.api.model.layers.InteractableLayer;
@@ -66,12 +68,18 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
     private static @Nullable SearchBar searchBar;
 
     private final Map<UniversalLayerRenderer, Map<ILocationProvider, List<Displayable>>> overlays = new IdentityHashMap<>();
-    private final Map<LayerManager, Long> overlayRefreshVersions = new IdentityHashMap<>();
     private final Map<MarkerOverlay, MapMarker> markerProperties = new IdentityHashMap<>();
+    private final Set<LayerManager> dirtyLayers = Collections
+        .synchronizedSet(Collections.newSetFromMap(new IdentityHashMap<>()));
     private @Nullable OverlayListener hoveredOverlay;
     private boolean actionKeyDown;
     private boolean fullscreenActive;
-    private long lastOverlayUpdate;
+    private @Nullable Context.UI overlayUi;
+    private int overlayDimension = Integer.MIN_VALUE;
+    private int overlayCenterX = Integer.MIN_VALUE;
+    private int overlayCenterZ = Integer.MIN_VALUE;
+    private int overlayWidth = -1;
+    private int overlayHeight = -1;
     private long lastRecache;
     private int oldCenterX = Integer.MIN_VALUE;
     private int oldCenterZ = Integer.MIN_VALUE;
@@ -97,6 +105,7 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
         FMLCommonHandler.instance()
             .bus()
             .register(this);
+        dirtyLayers.addAll(NavigatorApi.getEnabledLayers(MOD));
     }
 
     public static @Nullable IClientAPI getApi() {
@@ -125,23 +134,26 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
     }
 
     private void onDisplayUpdate(DisplayUpdateEvent event) {
-        if (event.uiState.ui != Context.UI.Fullscreen || event.uiState.active == fullscreenActive) return;
-
-        fullscreenActive = event.uiState.active;
-        lastMarkerZoom = Integer.MIN_VALUE;
-        for (LayerManager manager : NavigatorApi.getEnabledLayers(MOD)) {
-            if (fullscreenActive) {
-                manager.onGuiOpened(MOD);
-                manager.forceRefresh();
-            } else {
-                manager.onGuiClosed(MOD);
+        if (event.uiState.ui == Context.UI.Fullscreen && event.uiState.active != fullscreenActive) {
+            fullscreenActive = event.uiState.active;
+            lastMarkerZoom = Integer.MIN_VALUE;
+            for (LayerManager manager : NavigatorApi.getEnabledLayers(MOD)) {
+                if (fullscreenActive) {
+                    manager.onGuiOpened(MOD);
+                    manager.forceRefresh();
+                } else {
+                    manager.onGuiClosed(MOD);
+                }
+            }
+            if (!fullscreenActive) {
+                resetMarkerScales();
+                fullscreen = null;
+                searchBar = null;
             }
         }
-        if (!fullscreenActive) {
-            resetMarkerScales();
-            fullscreen = null;
-            searchBar = null;
-        }
+
+        UIState state = getActiveMapState();
+        if (state != null) syncVisibleOverlays(state);
     }
 
     private void onButtons(FullscreenDisplayEvent.AddonButtonDisplayEvent event) {
@@ -232,40 +244,26 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
         handleMarkerActionKey();
         if (searchBar != null && searchBar.getVisible()) searchBar.updateCursorCounter();
 
-        // Navigator caches locations by viewport; poll until that cache can publish change events.
-        if (System.currentTimeMillis() - lastOverlayUpdate < 250L) return;
-
-        lastOverlayUpdate = System.currentTimeMillis();
         Minecraft minecraft = Minecraft.getMinecraft();
         if (minecraft.thePlayer == null || minecraft.theWorld == null) {
             removeAllOverlays();
+            dirtyLayers.addAll(NavigatorApi.getEnabledLayers(MOD));
             return;
         }
 
         UIState state = getActiveMapState();
-        for (LayerManager manager : NavigatorApi.getEnabledLayers(MOD)) {
-            LayerRenderer layer = manager.getLayerRenderer(MOD);
-            if (!(layer instanceof UniversalLayerRenderer renderer) || !renderer.hasJourneyMapV6Overlays()) {
-                continue;
-            }
-            if (!manager.isLayerActive()) {
-                removeOverlays(renderer);
-                continue;
-            }
-            if (state == null) continue;
-
-            long refreshVersion = manager.getRefreshVersion();
-            boolean refresh = overlayRefreshVersions.getOrDefault(manager, -1L) != refreshVersion;
-            int width = (int) Math.ceil(state.blockBounds.maxX - state.blockBounds.minX);
-            int height = (int) Math.ceil(state.blockBounds.maxZ - state.blockBounds.minZ);
-            if (state.ui == Context.UI.Fullscreen) {
-                manager.recacheFullscreenMap(state.mapCenter.getX(), state.mapCenter.getZ(), width, height);
-            } else {
-                manager.recacheMiniMap(state.mapCenter.getX(), state.mapCenter.getZ(), width, height);
-            }
-            syncOverlays(renderer, refresh);
-            overlayRefreshVersions.put(manager, refreshVersion);
+        if (state == null) return;
+        if (overlayViewportChanged(state)) {
+            syncVisibleOverlays(state);
+        } else {
+            for (LayerManager manager : drainDirtyLayers()) syncLayerOverlays(manager, state, true);
         }
+    }
+
+    @SubscribeEvent
+    public void onLayerRefresh(LayerRefreshEvent event) {
+        if (event.getLayerManager()
+            .isEnabled(MOD)) dirtyLayers.add(event.getLayerManager());
     }
 
     private @Nullable UIState getActiveMapState() {
@@ -278,6 +276,76 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
 
     private boolean isUsable(@Nullable UIState state) {
         return state != null && state.active && state.blockBounds != null && state.mapCenter != null;
+    }
+
+    private void syncVisibleOverlays(UIState state) {
+        for (LayerManager manager : NavigatorApi.getEnabledLayers(MOD)) {
+            syncLayerOverlays(manager, state, consumeDirtyLayer(manager));
+        }
+        overlayUi = state.ui;
+        overlayDimension = state.dimension;
+        overlayCenterX = getOverlayCenterX(state);
+        overlayCenterZ = getOverlayCenterZ(state);
+        overlayWidth = (int) Math.ceil(state.blockBounds.maxX - state.blockBounds.minX);
+        overlayHeight = (int) Math.ceil(state.blockBounds.maxZ - state.blockBounds.minZ);
+    }
+
+    private boolean overlayViewportChanged(UIState state) {
+        return overlayUi != state.ui || overlayDimension != state.dimension
+            || overlayCenterX != getOverlayCenterX(state)
+            || overlayCenterZ != getOverlayCenterZ(state)
+            || overlayWidth != (int) Math.ceil(state.blockBounds.maxX - state.blockBounds.minX)
+            || overlayHeight != (int) Math.ceil(state.blockBounds.maxZ - state.blockBounds.minZ);
+    }
+
+    private void syncLayerOverlays(LayerManager manager, UIState state, boolean refresh) {
+        LayerRenderer layer = manager.getLayerRenderer(MOD);
+        if (!(layer instanceof UniversalLayerRenderer renderer) || !renderer.hasJourneyMapV6Overlays()) return;
+        if (!manager.isLayerActive()) {
+            removeOverlays(renderer);
+            return;
+        }
+
+        int width = (int) Math.ceil(state.blockBounds.maxX - state.blockBounds.minX);
+        int height = (int) Math.ceil(state.blockBounds.maxZ - state.blockBounds.minZ);
+        if (state.ui == Context.UI.Fullscreen) {
+            manager.recacheFullscreenMap(getOverlayCenterX(state), getOverlayCenterZ(state), width, height);
+        } else {
+            manager.recacheMiniMap(getOverlayCenterX(state), getOverlayCenterZ(state), width, height);
+        }
+        syncOverlays(renderer, refresh);
+    }
+
+    private int getOverlayCenterX(UIState state) {
+        if (state.ui == Context.UI.Fullscreen && fullscreen != null && fullscreen.getUiState().active) {
+            return (int) Math.round(fullscreen.getCenterBlockX(true));
+        }
+        Minecraft minecraft = Minecraft.getMinecraft();
+        return state.ui == Context.UI.Minimap && minecraft.thePlayer != null ? (int) minecraft.thePlayer.posX
+            : state.mapCenter.getX();
+    }
+
+    private int getOverlayCenterZ(UIState state) {
+        if (state.ui == Context.UI.Fullscreen && fullscreen != null && fullscreen.getUiState().active) {
+            return (int) Math.round(fullscreen.getCenterBlockZ(true));
+        }
+        Minecraft minecraft = Minecraft.getMinecraft();
+        return state.ui == Context.UI.Minimap && minecraft.thePlayer != null ? (int) minecraft.thePlayer.posZ
+            : state.mapCenter.getZ();
+    }
+
+    private boolean consumeDirtyLayer(LayerManager manager) {
+        synchronized (dirtyLayers) {
+            return dirtyLayers.remove(manager);
+        }
+    }
+
+    private List<LayerManager> drainDirtyLayers() {
+        synchronized (dirtyLayers) {
+            List<LayerManager> layers = new ArrayList<>(dirtyLayers);
+            dirtyLayers.clear();
+            return layers;
+        }
     }
 
     private void syncOverlays(UniversalLayerRenderer renderer, boolean refresh) {
@@ -323,14 +391,12 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
             shown.put(location, overlays);
         }
 
-        if (refresh) {
-            shown.entrySet()
-                .removeIf(entry -> {
-                    if (visible.contains(entry.getKey())) return false;
-                    removeOverlays(entry.getValue());
-                    return true;
-                });
-        }
+        shown.entrySet()
+            .removeIf(entry -> {
+                if (visible.contains(entry.getKey())) return false;
+                removeOverlays(entry.getValue());
+                return true;
+            });
     }
 
     private @Nullable MarkerOverlay createMarker(UniversalLayerRenderer renderer, UniversalRenderStep<?> step) {
@@ -497,8 +563,13 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
                 shown -> shown.values()
                     .forEach(this::removeOverlays));
         overlays.clear();
-        overlayRefreshVersions.clear();
         markerProperties.clear();
+        overlayUi = null;
+        overlayDimension = Integer.MIN_VALUE;
+        overlayCenterX = Integer.MIN_VALUE;
+        overlayCenterZ = Integer.MIN_VALUE;
+        overlayWidth = -1;
+        overlayHeight = -1;
         clearHoveredOverlay();
     }
 
@@ -677,7 +748,7 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
             searchBar.setTextConsumer(
                 text -> NavigatorApi.getEnabledLayers(MOD)
                     .forEach(manager -> {
-                        if (manager.isLayerActive() && manager.hasSearchField()) {
+                        if (manager.hasSearchField()) {
                             manager.onSearch(text);
                             manager.forceRefresh();
                         }

--- a/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
+++ b/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
@@ -158,6 +158,7 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
             for (LayerManager manager : NavigatorApi.getEnabledLayers(MOD)) {
                 if (fullscreenActive) {
                     manager.onGuiOpened(MOD);
+                    if (manager.hasSearchField()) manager.onSearch(SearchBar.getRestoredText());
                     manager.forceRefresh();
                 } else {
                     manager.onGuiClosed(MOD);
@@ -762,6 +763,7 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
     }
 
     private void drawSearchBar(FullscreenRenderEvent event) {
+        if (!fullscreenActive) return;
         boolean visible = NavigatorApi.getEnabledLayers(MOD)
             .stream()
             .anyMatch(manager -> manager.isLayerActive() && manager.hasSearchField());
@@ -785,7 +787,8 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
                             manager.onSearch(text);
                             manager.forceRefresh();
                         }
-                    }));
+                    }),
+                false);
         }
         searchBar.setVisible(true);
         searchBar.drawTextBox();

--- a/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
+++ b/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
@@ -1,0 +1,219 @@
+package com.gtnewhorizons.navigator.internal.journeymap.v6;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.ScaledResolution;
+
+import com.gtnewhorizons.navigator.Navigator;
+import com.gtnewhorizons.navigator.api.NavigatorApi;
+import com.gtnewhorizons.navigator.api.model.SupportedMods;
+import com.gtnewhorizons.navigator.api.model.buttons.ButtonManager;
+import com.gtnewhorizons.navigator.api.model.layers.InteractableLayer;
+import com.gtnewhorizons.navigator.api.model.layers.LayerManager;
+import com.gtnewhorizons.navigator.api.model.layers.LayerRenderer;
+import com.gtnewhorizons.navigator.api.model.layers.UniversalLayerRenderer;
+import com.gtnewhorizons.navigator.api.model.steps.UniversalRenderStep;
+import com.gtnewhorizons.navigator.api.util.DrawUtils;
+
+import journeymap.api.v2.client.IClientAPI;
+import journeymap.api.v2.client.IClientPlugin;
+import journeymap.api.v2.client.event.DisplayUpdateEvent;
+import journeymap.api.v2.client.event.FullscreenDisplayEvent;
+import journeymap.api.v2.client.event.FullscreenMapEvent;
+import journeymap.api.v2.client.event.FullscreenRenderEvent;
+import journeymap.api.v2.client.fullscreen.IFullscreen;
+import journeymap.api.v2.client.fullscreen.IThemeButton;
+import journeymap.api.v2.client.util.UIState;
+import journeymap.api.v2.common.Context;
+import journeymap.api.v2.common.JourneyMapPlugin;
+import journeymap.api.v2.common.event.ClientEventRegistry;
+import journeymap.api.v2.common.event.FullscreenEventRegistry;
+import journeymap.api.v2.common.util.BlockPos;
+
+@JourneyMapPlugin(apiVersion = IClientAPI.API_VERSION, dependencies = Navigator.MODID)
+public final class JourneyMapV6Plugin implements IClientPlugin {
+
+    private static final SupportedMods MOD = SupportedMods.JourneyMap;
+
+    private static IClientAPI api;
+    private static IFullscreen fullscreen;
+
+    private boolean fullscreenActive;
+    private long lastRecache;
+    private int oldCenterX = Integer.MIN_VALUE;
+    private int oldCenterZ = Integer.MIN_VALUE;
+    private int oldWidth = -1;
+    private int oldHeight = -1;
+    private long timeLastClick;
+    private int oldMouseX;
+    private int oldMouseY;
+    private ButtonManager lastPressedButton;
+    private long lastButtonPress;
+
+    @Override
+    public String getModId() {
+        return Navigator.MODID;
+    }
+
+    @Override
+    public void initialize(IClientAPI clientApi) {
+        api = clientApi;
+        ClientEventRegistry.DISPLAY_UPDATE_EVENT.subscribe(Navigator.MODID, this::onDisplayUpdate);
+        FullscreenEventRegistry.FULLSCREEN_RENDER_EVENT.subscribe(Navigator.MODID, this::onRender);
+        FullscreenEventRegistry.FULLSCREEN_MAP_CLICK_EVENT.subscribe(Navigator.MODID, this::onClick);
+        FullscreenEventRegistry.ADDON_BUTTON_DISPLAY_EVENT.subscribe(Navigator.MODID, this::onButtons);
+    }
+
+    public static @Nullable IClientAPI getApi() {
+        return api;
+    }
+
+    public static void centerOn(int blockX, int blockZ) {
+        if (fullscreen != null && fullscreen.getUiState().active) {
+            fullscreen.centerOn(blockX, blockZ);
+        }
+    }
+
+    private void onDisplayUpdate(DisplayUpdateEvent event) {
+        if (event.uiState.ui != Context.UI.Fullscreen || event.uiState.active == fullscreenActive) return;
+
+        fullscreenActive = event.uiState.active;
+        for (LayerManager manager : NavigatorApi.getEnabledLayers(MOD)) {
+            if (fullscreenActive) {
+                manager.onGuiOpened(MOD);
+                manager.forceRefresh();
+            } else {
+                manager.onGuiClosed(MOD);
+            }
+        }
+        if (!fullscreenActive) fullscreen = null;
+    }
+
+    private void onButtons(FullscreenDisplayEvent.AddonButtonDisplayEvent event) {
+        fullscreen = event.getFullscreen();
+        for (ButtonManager manager : NavigatorApi.getEnabledButtons(MOD)) {
+            IThemeButton button = event.getThemeButtonDisplay()
+                .addThemeToggleButton(
+                    manager.getButtonText(),
+                    manager.getIcon(MOD, ""),
+                    manager.isActive(),
+                    ignored -> toggleButton(manager));
+            manager.setOnToggle(button::setToggled);
+        }
+    }
+
+    private void toggleButton(ButtonManager manager) {
+        long now = System.nanoTime();
+        // JM 6.0.0-beta.1 adds addon buttons to the fullscreen twice and invokes both entries on one click.
+        if (manager == lastPressedButton && now - lastButtonPress < 50_000_000L) return;
+
+        lastPressedButton = manager;
+        lastButtonPress = now;
+        manager.toggle();
+    }
+
+    private void onRender(FullscreenRenderEvent event) {
+        fullscreen = event.getFullscreen();
+        UIState state = fullscreen.getUiState();
+        if (!state.active || state.blockBounds == null || state.displayBounds == null || state.blockSize <= 0) return;
+
+        int centerX = (int) Math.round(fullscreen.getCenterBlockX(true));
+        int centerZ = (int) Math.round(fullscreen.getCenterBlockZ(true));
+        int width = (int) Math.ceil(state.blockBounds.maxX - state.blockBounds.minX);
+        int height = (int) Math.ceil(state.blockBounds.maxZ - state.blockBounds.minZ);
+        recache(centerX, centerZ, width, height);
+
+        Minecraft minecraft = fullscreen.getMinecraft();
+        int guiScale = new ScaledResolution(minecraft, minecraft.displayWidth, minecraft.displayHeight)
+            .getScaleFactor();
+        double blockSize = state.blockSize / guiScale;
+        double mapCenterX = fullscreen.getCenterBlockX(true);
+        double mapCenterZ = fullscreen.getCenterBlockZ(true);
+        double zoomStep = Math.log(state.blockSize) / Math.log(2.0);
+        for (LayerRenderer renderer : NavigatorApi.getActiveRenderersByPriority(MOD)) {
+            if (!(renderer instanceof UniversalLayerRenderer)) continue;
+            for (UniversalRenderStep<?> step : ((UniversalLayerRenderer) renderer).getRenderSteps()) {
+                double x = state.displayBounds.getCenterX() / guiScale + (step.getLocation()
+                    .getBlockX() - mapCenterX) * blockSize;
+                double y = state.displayBounds.getCenterY() / guiScale + (step.getLocation()
+                    .getBlockZ() - mapCenterZ) * blockSize;
+                step.drawJourneyMap(x, y, 1.0F / guiScale, zoomStep, blockSize, 1.0, 0.0);
+            }
+        }
+
+        drawTooltip(event);
+    }
+
+    private void recache(int centerX, int centerZ, int width, int height) {
+        long now = System.currentTimeMillis();
+        boolean viewportChanged = oldCenterX != centerX || oldCenterZ != centerZ
+            || oldWidth != width
+            || oldHeight != height;
+        for (LayerManager manager : NavigatorApi.getEnabledLayers(MOD)) {
+            if (manager.isLayerActive() && (viewportChanged || manager.forceRefresh || now - lastRecache >= 1000L)) {
+                manager.recacheFullscreenMap(centerX, centerZ, width, height);
+            }
+        }
+        if (viewportChanged || now - lastRecache >= 1000L) {
+            oldCenterX = centerX;
+            oldCenterZ = centerZ;
+            oldWidth = width;
+            oldHeight = height;
+            lastRecache = now;
+        }
+    }
+
+    private void drawTooltip(FullscreenRenderEvent event) {
+        for (LayerRenderer renderer : NavigatorApi.getActiveRenderersFor(MOD)) {
+            if (!(renderer instanceof InteractableLayer interactable)) continue;
+
+            interactable.onMouseMove(event.getMouseX(), event.getMouseY());
+            List<String> tooltip = interactable.getTooltip();
+            if (!tooltip.isEmpty()) {
+                DrawUtils.drawSimpleTooltip(
+                    event.getFullscreen()
+                        .getScreen(),
+                    tooltip,
+                    event.getMouseX() + 16,
+                    event.getMouseY() - 12,
+                    0xFFFFFFFF,
+                    0x86000000);
+            } else {
+                interactable.drawCustomTooltip(
+                    event.getFullscreen()
+                        .getMinecraft().fontRenderer,
+                    event.getMouseX(),
+                    event.getMouseY(),
+                    event.getFullscreen()
+                        .getScreen().width,
+                    event.getFullscreen()
+                        .getScreen().height);
+            }
+            return;
+        }
+    }
+
+    private void onClick(FullscreenMapEvent.ClickEvent event) {
+        if (event.getStage() != FullscreenMapEvent.Stage.PRE || event.getButton() != 0) return;
+
+        int mouseX = (int) event.getMouseX();
+        int mouseY = (int) event.getMouseY();
+        long now = System.currentTimeMillis();
+        boolean doubleClick = mouseX == oldMouseX && mouseY == oldMouseY && now - timeLastClick < 250L;
+        oldMouseX = mouseX;
+        oldMouseY = mouseY;
+        timeLastClick = now;
+
+        BlockPos location = event.getLocation();
+        for (LayerRenderer renderer : NavigatorApi.getActiveRenderersFor(MOD)) {
+            if (renderer instanceof InteractableLayer interactable
+                && interactable.onMapClick(doubleClick, mouseX, mouseY, location.getX(), location.getZ())) {
+                event.cancel();
+                return;
+            }
+        }
+    }
+}

--- a/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
+++ b/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
@@ -797,6 +797,7 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
         int framebufferMouseX = (int) event.getMouseX();
         int framebufferMouseY = (int) event.getMouseY();
         Minecraft minecraft = fullscreen.getMinecraft();
+        if (minecraft == null) return;
         int guiScale = new ScaledResolution(minecraft, minecraft.displayWidth, minecraft.displayHeight)
             .getScaleFactor();
         int mouseX = framebufferMouseX / guiScale;

--- a/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
+++ b/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
@@ -353,7 +353,14 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
         if (marker.getImage() != null) {
             image = new MapImage(marker.getImage());
         } else if (marker.getImageLocation() != null) {
-            image = new MapImage(marker.getImageLocation(), marker.getTextureWidth(), marker.getTextureHeight());
+            image = new MapImage(
+                marker.getImageLocation(),
+                marker.getTextureX(),
+                marker.getTextureY(),
+                marker.getTextureWidth(),
+                marker.getTextureHeight(),
+                0xFFFFFF,
+                1.0F);
         } else {
             return null;
         }

--- a/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
+++ b/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6Plugin.java
@@ -567,8 +567,19 @@ public final class JourneyMapV6Plugin implements IClientPlugin {
     private void handleMarkerActionKey() {
         int keyCode = NavigatorApi.ACTION_KEY.getKeyCode();
         boolean down = keyCode >= 0 && keyCode < 256 && Keyboard.isKeyDown(keyCode);
-        if (down && !actionKeyDown && hoveredOverlay != null) {
-            hoveredOverlay.renderer.onRenderStepKeyPressed(hoveredOverlay.step, keyCode);
+        if (down && !actionKeyDown
+            && fullscreen != null
+            && fullscreen.getScreen() == Minecraft.getMinecraft().currentScreen) {
+            if (hoveredOverlay != null) {
+                hoveredOverlay.renderer.onRenderStepKeyPressed(hoveredOverlay.step, keyCode);
+            } else {
+                for (LayerRenderer renderer : NavigatorApi.getActiveRenderersFor(MOD)) {
+                    if (renderer instanceof UniversalLayerRenderer universal && universal.hasJourneyMapV6Overlays()) {
+                        continue;
+                    }
+                    if (renderer instanceof InteractableLayer interactable && interactable.onKeyPressed(keyCode)) break;
+                }
+            }
         }
         actionKeyDown = down;
     }

--- a/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6WaypointManager.java
+++ b/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6WaypointManager.java
@@ -1,0 +1,62 @@
+package com.gtnewhorizons.navigator.internal.journeymap.v6;
+
+import com.gtnewhorizons.navigator.Navigator;
+import com.gtnewhorizons.navigator.api.model.SupportedMods;
+import com.gtnewhorizons.navigator.api.model.layers.InteractableLayerManager;
+import com.gtnewhorizons.navigator.api.model.waypoints.Waypoint;
+import com.gtnewhorizons.navigator.api.model.waypoints.WaypointManager;
+
+import journeymap.api.v2.client.IClientAPI;
+import journeymap.api.v2.common.util.BlockPos;
+import journeymap.api.v2.common.waypoint.WaypointFactory;
+
+public final class JourneyMapV6WaypointManager extends WaypointManager {
+
+    private journeymap.api.v2.common.waypoint.Waypoint journeyMapWaypoint;
+
+    public JourneyMapV6WaypointManager(InteractableLayerManager layerManager) {
+        super(layerManager, SupportedMods.JourneyMap);
+    }
+
+    @Override
+    public void clearActiveWaypoint() {
+        IClientAPI api = JourneyMapV6Plugin.getApi();
+        if (api != null && journeyMapWaypoint != null) {
+            api.removeWaypoint(Navigator.MODID, journeyMapWaypoint);
+        }
+        journeyMapWaypoint = null;
+    }
+
+    @Override
+    public void updateActiveWaypoint(Waypoint waypoint) {
+        if (matches(waypoint)) return;
+
+        clearActiveWaypoint();
+        IClientAPI api = JourneyMapV6Plugin.getApi();
+        if (api == null) return;
+
+        journeyMapWaypoint = WaypointFactory.createWaypoint(
+            Navigator.MODID,
+            new BlockPos(waypoint.blockX, waypoint.blockY, waypoint.blockZ),
+            waypoint.label,
+            waypoint.dimensionId,
+            false);
+        journeyMapWaypoint.setColor(waypoint.color);
+        api.addWaypoint(Navigator.MODID, journeyMapWaypoint);
+    }
+
+    @Override
+    public boolean hasWaypoint() {
+        return journeyMapWaypoint != null;
+    }
+
+    private boolean matches(Waypoint waypoint) {
+        return journeyMapWaypoint != null && waypoint.blockX == journeyMapWaypoint.getX()
+            && waypoint.blockY == journeyMapWaypoint.getY()
+            && waypoint.blockZ == journeyMapWaypoint.getZ()
+            && journeyMapWaypoint.getDimensions()
+                .contains(String.valueOf(waypoint.dimensionId))
+            && waypoint.label.equals(journeyMapWaypoint.getName())
+            && waypoint.color == journeyMapWaypoint.getColor();
+    }
+}

--- a/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6WaypointManager.java
+++ b/src/main/java/com/gtnewhorizons/navigator/internal/journeymap/v6/JourneyMapV6WaypointManager.java
@@ -1,5 +1,7 @@
 package com.gtnewhorizons.navigator.internal.journeymap.v6;
 
+import java.util.Objects;
+
 import com.gtnewhorizons.navigator.Navigator;
 import com.gtnewhorizons.navigator.api.model.SupportedMods;
 import com.gtnewhorizons.navigator.api.model.layers.InteractableLayerManager;
@@ -56,7 +58,7 @@ public final class JourneyMapV6WaypointManager extends WaypointManager {
             && waypoint.blockZ == journeyMapWaypoint.getZ()
             && journeyMapWaypoint.getDimensions()
                 .contains(String.valueOf(waypoint.dimensionId))
-            && waypoint.label.equals(journeyMapWaypoint.getName())
+            && Objects.equals(waypoint.label, journeyMapWaypoint.getName())
             && waypoint.color == journeyMapWaypoint.getColor();
     }
 }

--- a/src/main/java/com/gtnewhorizons/navigator/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizons/navigator/mixins/Mixins.java
@@ -28,6 +28,11 @@ public enum Mixins implements IMixins {
             "journeymap.RenderWaypointBeaconMixin",
             "journeymap.WaypointManagerMixin",
             "journeymap.TextureCacheMixin")),
+    JOURNEYMAP_V6(new MixinBuilder()
+        .addRequiredMod(TargetedMod.JOURNEYMAP)
+        .setPhase(Phase.LATE)
+        .setApplyIf(() -> ModuleConfig.enableJourneyMapModule && Util.isJourneyMapV6Installed())
+        .addClientMixins("journeymap.v6.FullscreenMixin")),
     XAEROS_GUI(new MixinBuilder()
         .addRequiredMod(TargetedMod.XAEROWORLDMAP)
         .setPhase(Phase.LATE)

--- a/src/main/java/com/gtnewhorizons/navigator/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizons/navigator/mixins/Mixins.java
@@ -32,7 +32,7 @@ public enum Mixins implements IMixins {
         .addRequiredMod(TargetedMod.JOURNEYMAP)
         .setPhase(Phase.LATE)
         .setApplyIf(() -> ModuleConfig.enableJourneyMapModule && Util.isJourneyMapV6Installed())
-        .addClientMixins("journeymap.v6.FullscreenMixin")),
+        .addClientMixins("journeymap.v6.FullscreenMixin", "journeymap.v6.MapChatMixin")),
     XAEROS_GUI(new MixinBuilder()
         .addRequiredMod(TargetedMod.XAEROWORLDMAP)
         .setPhase(Phase.LATE)

--- a/src/main/java/com/gtnewhorizons/navigator/mixins/late/journeymap/FullscreenMixin.java
+++ b/src/main/java/com/gtnewhorizons/navigator/mixins/late/journeymap/FullscreenMixin.java
@@ -24,6 +24,7 @@ import com.gtnewhorizons.navigator.api.model.layers.LayerManager;
 import com.gtnewhorizons.navigator.api.model.layers.LayerRenderer;
 import com.gtnewhorizons.navigator.api.model.layers.UniversalLayerRenderer;
 import com.gtnewhorizons.navigator.internal.SearchBar;
+import com.gtnewhorizons.navigator.internal.journeymap.v5.JourneyMapV5Renderer;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
@@ -31,7 +32,6 @@ import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 
 import journeymap.client.io.ThemeFileHandler;
 import journeymap.client.model.BlockCoordIntPair;
-import journeymap.client.render.draw.DrawStep;
 import journeymap.client.render.map.GridRenderer;
 import journeymap.client.ui.component.ButtonList;
 import journeymap.client.ui.component.JmUI;
@@ -125,7 +125,6 @@ public abstract class FullscreenMixin extends JmUI {
         at = @At(value = "INVOKE", target = "Ljourneymap/client/model/MapState;getDrawWaypointSteps()Ljava/util/List;"),
         remap = false,
         require = 1)
-    @SuppressWarnings("unchecked")
     private void navigator$onBeforeDrawJourneyMapWaypoints(CallbackInfo ci, @Local(ordinal = 0) int xOffset,
         @Local(ordinal = 1) int yOffset, @Local float drawScale) {
         final int fontScale = getMapFontScale();
@@ -142,8 +141,10 @@ public abstract class FullscreenMixin extends JmUI {
 
         for (LayerRenderer layer : NavigatorApi.getActiveRenderersByPriority(JourneyMap)) {
             if (layer instanceof JMLayerRenderer || layer instanceof UniversalLayerRenderer) {
-                List<? extends DrawStep> steps = (List<? extends DrawStep>) layer.getRenderSteps();
-                gridRenderer.draw(steps, xOffset, yOffset, drawScale, fontScale, 0.0);
+                layer.getRenderSteps()
+                    .forEach(
+                        step -> JourneyMapV5Renderer
+                            .draw(step, xOffset, yOffset, gridRenderer, drawScale, fontScale, 0.0));
             }
         }
 

--- a/src/main/java/com/gtnewhorizons/navigator/mixins/late/journeymap/FullscreenMixin.java
+++ b/src/main/java/com/gtnewhorizons/navigator/mixins/late/journeymap/FullscreenMixin.java
@@ -114,7 +114,7 @@ public abstract class FullscreenMixin extends JmUI {
         navigator$searchBar.setTextConsumer(
             text -> NavigatorApi.getEnabledLayers(JourneyMap)
                 .forEach(layerManager -> {
-                    if (layerManager.isLayerActive() && layerManager.hasSearchField()) {
+                    if (layerManager.hasSearchField()) {
                         layerManager.onSearch(text);
                     }
                 }));

--- a/src/main/java/com/gtnewhorizons/navigator/mixins/late/journeymap/MiniMapMixin.java
+++ b/src/main/java/com/gtnewhorizons/navigator/mixins/late/journeymap/MiniMapMixin.java
@@ -15,8 +15,8 @@ import com.gtnewhorizons.navigator.api.NavigatorApi;
 import com.gtnewhorizons.navigator.api.model.layers.LayerManager;
 import com.gtnewhorizons.navigator.api.model.layers.LayerRenderer;
 import com.gtnewhorizons.navigator.api.model.steps.RenderStep;
+import com.gtnewhorizons.navigator.internal.journeymap.v5.JourneyMapV5Renderer;
 
-import journeymap.client.render.draw.DrawStep;
 import journeymap.client.render.map.GridRenderer;
 import journeymap.client.ui.minimap.DisplayVars;
 import journeymap.client.ui.minimap.MiniMap;
@@ -57,15 +57,14 @@ public abstract class MiniMapMixin {
 
         for (LayerRenderer layerRenderer : NavigatorApi.getActiveRenderersByPriority(JourneyMap)) {
             for (RenderStep renderStep : layerRenderer.getRenderSteps()) {
-                if (renderStep instanceof DrawStep drawStep) {
-                    drawStep.draw(
-                        0.0D,
-                        0.0D,
-                        gridRenderer,
-                        ((DisplayVarsAccessor) dv).getDrawScale(),
-                        ((DisplayVarsAccessor) dv).getFontScale(),
-                        rotation);
-                }
+                JourneyMapV5Renderer.draw(
+                    renderStep,
+                    0.0D,
+                    0.0D,
+                    gridRenderer,
+                    ((DisplayVarsAccessor) dv).getDrawScale(),
+                    ((DisplayVarsAccessor) dv).getFontScale(),
+                    rotation);
             }
         }
     }

--- a/src/main/java/com/gtnewhorizons/navigator/mixins/late/journeymap/v6/FullscreenMixin.java
+++ b/src/main/java/com/gtnewhorizons/navigator/mixins/late/journeymap/v6/FullscreenMixin.java
@@ -30,6 +30,11 @@ public abstract class FullscreenMixin {
         }
     }
 
+    @Inject(method = "openChat", at = @At("HEAD"), remap = false)
+    private void navigator$releaseSearchFocus(String defaultText, CallbackInfo ci) {
+        JourneyMapV6Plugin.onChatOpened();
+    }
+
     @Inject(method = "isSearchFocused", at = @At("RETURN"), cancellable = true, remap = false)
     private void navigator$includeNavigatorSearch(CallbackInfoReturnable<Boolean> cir) {
         if (JourneyMapV6Plugin.isSearchFocused()) cir.setReturnValue(true);

--- a/src/main/java/com/gtnewhorizons/navigator/mixins/late/journeymap/v6/FullscreenMixin.java
+++ b/src/main/java/com/gtnewhorizons/navigator/mixins/late/journeymap/v6/FullscreenMixin.java
@@ -1,0 +1,37 @@
+package com.gtnewhorizons.navigator.mixins.late.journeymap.v6;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.gtnewhorizons.navigator.internal.journeymap.v6.JourneyMapV6Plugin;
+
+import journeymap.client.ui.fullscreen.Fullscreen;
+import journeymap.client.ui.fullscreen.MapChat;
+
+@Mixin(Fullscreen.class)
+public abstract class FullscreenMixin {
+
+    @Shadow(remap = false)
+    private MapChat chat;
+
+    @Inject(method = "keyTyped", at = @At("HEAD"), cancellable = true)
+    private void navigator$onKeyTyped(char typedChar, int keyCode, CallbackInfo ci) {
+        if ((chat == null || chat.isHidden()) && JourneyMapV6Plugin.onSearchKeyTyped(typedChar, keyCode)) ci.cancel();
+    }
+
+    @Inject(method = "mouseClicked", at = @At("HEAD"), cancellable = true)
+    private void navigator$onMouseClicked(int mouseX, int mouseY, int button, CallbackInfo ci) {
+        if ((chat == null || chat.isHidden()) && JourneyMapV6Plugin.onSearchMouseClicked(mouseX, mouseY, button)) {
+            ci.cancel();
+        }
+    }
+
+    @Inject(method = "isSearchFocused", at = @At("RETURN"), cancellable = true, remap = false)
+    private void navigator$includeNavigatorSearch(CallbackInfoReturnable<Boolean> cir) {
+        if (JourneyMapV6Plugin.isSearchFocused()) cir.setReturnValue(true);
+    }
+}

--- a/src/main/java/com/gtnewhorizons/navigator/mixins/late/journeymap/v6/MapChatMixin.java
+++ b/src/main/java/com/gtnewhorizons/navigator/mixins/late/journeymap/v6/MapChatMixin.java
@@ -1,0 +1,28 @@
+package com.gtnewhorizons.navigator.mixins.late.journeymap.v6;
+
+import net.minecraft.client.gui.GuiChat;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import journeymap.client.ui.fullscreen.MapChat;
+
+@Mixin(MapChat.class)
+public abstract class MapChatMixin extends GuiChat {
+
+    @Shadow(remap = false)
+    protected boolean hidden;
+
+    @Inject(method = "drawScreen", at = @At("HEAD"))
+    private void navigator$unfocusHiddenInput(int mouseX, int mouseY, float partialTicks, CallbackInfo ci) {
+        if (hidden && inputField != null && inputField.isFocused()) inputField.setFocused(false);
+    }
+
+    @Inject(method = "setHidden", at = @At("TAIL"), remap = false)
+    private void navigator$restoreInputState(boolean hidden, CallbackInfo ci) {
+        if (inputField != null) inputField.setFocused(!hidden);
+    }
+}

--- a/src/main/java/com/gtnewhorizons/navigator/mixins/late/xaerosworldmap/GuiMapMixin.java
+++ b/src/main/java/com/gtnewhorizons/navigator/mixins/late/xaerosworldmap/GuiMapMixin.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.gui.GuiTextField;
 
 import org.spongepowered.asm.lib.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
@@ -78,6 +79,9 @@ public abstract class GuiMapMixin extends ScreenBase {
 
     @Shadow
     public abstract void addGuiButton(GuiButton b);
+
+    @Shadow
+    public abstract void setFocused(GuiTextField field);
 
     @Shadow
     private int screenScale;
@@ -245,17 +249,18 @@ public abstract class GuiMapMixin extends ScreenBase {
         }
     }
 
-    @Inject(method = "mouseClicked", at = @At(value = "HEAD"), cancellable = true)
+    @Inject(method = "mouseClicked", at = @At(value = "HEAD"), cancellable = true, remap = true)
     private void navigator$mouseClicked(int x, int y, int button, CallbackInfo ci) {
         if (navigator$searchBar.getVisible()) {
             navigator$searchBar.mouseClicked(x, y, button);
             if (navigator$searchBar.isHovered(x, y)) {
+                setFocused(navigator$searchBar);
                 ci.cancel();
             }
         }
     }
 
-    @Inject(method = "keyTyped", at = @At(value = "HEAD"), cancellable = true)
+    @Inject(method = "keyTyped", at = @At(value = "HEAD"), cancellable = true, remap = true)
     private void navigator$keyTyped(char par1, int par2, CallbackInfo ci) {
         for (LayerManager layerManager : NavigatorApi.getEnabledLayers(XaeroWorldMap)) {
             if (layerManager.isLayerActive() && layerManager.hasSearchField()

--- a/src/main/java/com/gtnewhorizons/navigator/mixins/late/xaerosworldmap/GuiMapMixin.java
+++ b/src/main/java/com/gtnewhorizons/navigator/mixins/late/xaerosworldmap/GuiMapMixin.java
@@ -102,7 +102,7 @@ public abstract class GuiMapMixin extends ScreenBase {
         navigator$searchBar.setTextConsumer(
             text -> NavigatorApi.getEnabledLayers(XaeroWorldMap)
                 .forEach(layerManager -> {
-                    if (layerManager.isLayerActive() && layerManager.hasSearchField()) {
+                    if (layerManager.hasSearchField()) {
                         layerManager.onSearch(text);
                     }
                 }));


### PR DESCRIPTION
## Summary

- Add [JourneyMap 6](https://www.curseforge.com/minecraft/mc-mods/journeymap/files/all?page=1&pageSize=20&version=1.7.10&gameVersionTypeId=1&showAlphaFiles=show) integration alongside the existing JourneyMap 5 And Xaero implementation.
- Support JourneyMap 6 through native markers, images, and polygon overlays.
- Expand the map neutral API with collection backed locations, explicit cache invalidation, retained overlay refresh, and interaction independent of waypoint support. See [docs/API.md](url)
- Improve shared rendering with zoom aware labels/icons
- Flag the JourneyMap 5 specific rendering API as deprecated.

_Note: At the time of writing this the JM6 version currently on published have a few bugs impacting this PR. A new release should drop very soon which I tested fix every issues I encountered._

Sneak peak:
<img width="1501" height="911" alt="2026-07-24_22 41 40" src="https://github.com/user-attachments/assets/bc141c0c-58ac-4efa-ad1a-aff340bb0375" />
<img width="1501" height="911" alt="2026-07-24_22 41 55" src="https://github.com/user-attachments/assets/4bf3fc2b-97d3-4fdf-9a07-9ce31d6d364d" />



## Checklist
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [x] This PR requires another PR in order to merge
 - No but a few PR will depend on it.  Nothing will break though since old API path are deprecated but not deleted

