### PR TITLE
Fix atlas padding issues if texture filtering is enabled

### DIFF
--- a/src/main/java/com/gtnewhorizons/navigator/api/model/markers/MapMarker.java
+++ b/src/main/java/com/gtnewhorizons/navigator/api/model/markers/MapMarker.java
@@ -13,6 +13,7 @@ import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.util.ResourceLocation;
 
 import com.gtnewhorizons.navigator.api.model.steps.UniversalRenderStep;
+import com.gtnewhorizons.navigator.mixins.early.minecraft.TextureAtlasSpriteAccessor;
 
 /**
  * Map-neutral description of a JourneyMap 6 native point marker.
@@ -22,6 +23,8 @@ import com.gtnewhorizons.navigator.api.model.steps.UniversalRenderStep;
  */
 @SuppressWarnings("unused")
 public final class MapMarker {
+
+    private static final int ANISOTROPIC_PADDING = 8;
 
     private final @Nullable BufferedImage image;
     private final @Nullable ResourceLocation imageLocation;
@@ -72,12 +75,18 @@ public final class MapMarker {
 
     /**
      * Creates a marker from a sprite already stitched into a Minecraft texture atlas.
+     * Forge's anisotropic-filtering border is excluded from the source region.
      *
      * @param atlasLocation texture atlas resource
      * @param sprite        stitched sprite; animated atlas updates remain visible
      */
     public MapMarker(ResourceLocation atlasLocation, TextureAtlasSprite sprite) {
-        this(atlasLocation, sprite.getOriginX(), sprite.getOriginY(), sprite.getIconWidth(), sprite.getIconHeight());
+        this(
+            atlasLocation,
+            sprite.getOriginX() + spritePadding(sprite),
+            sprite.getOriginY() + spritePadding(sprite),
+            sprite.getIconWidth() - 2 * spritePadding(sprite),
+            sprite.getIconHeight() - 2 * spritePadding(sprite));
     }
 
     /**
@@ -298,6 +307,10 @@ public final class MapMarker {
         if (minScale <= 0 || maxScale <= 0) throw new IllegalArgumentException("zoom scales must be positive");
         if (maxZoom <= minZoom) throw new IllegalArgumentException("maxZoom must be greater than minZoom");
         return new double[] { minScale, maxScale, minZoom, maxZoom };
+    }
+
+    private static int spritePadding(TextureAtlasSprite sprite) {
+        return ((TextureAtlasSpriteAccessor) sprite).navigator$usesAnisotropicFiltering() ? ANISOTROPIC_PADDING : 0;
     }
 
     private static double interpolate(@Nullable double[] scale, double zoomStep) {

--- a/src/main/java/com/gtnewhorizons/navigator/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizons/navigator/mixins/Mixins.java
@@ -10,6 +10,9 @@ import com.gtnewhorizons.navigator.config.ModuleConfig;
 public enum Mixins implements IMixins {
 
     // spotless:off
+    TEXTURE_ATLAS_SPRITE_ACCESSOR(new MixinBuilder("Access texture atlas sprite padding state")
+        .setPhase(Phase.EARLY)
+        .addClientMixins("minecraft.TextureAtlasSpriteAccessor")),
     ENABLE_STENCIL(new MixinBuilder("Force enables stencil buffer")
         .addRequiredMod(TargetedMod.XAEROMINIMAP)
         .addRequiredMod(TargetedMod.XAEROWORLDMAP)

--- a/src/main/java/com/gtnewhorizons/navigator/mixins/early/minecraft/TextureAtlasSpriteAccessor.java
+++ b/src/main/java/com/gtnewhorizons/navigator/mixins/early/minecraft/TextureAtlasSpriteAccessor.java
@@ -1,0 +1,13 @@
+package com.gtnewhorizons.navigator.mixins.early.minecraft;
+
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(TextureAtlasSprite.class)
+public interface TextureAtlasSpriteAccessor {
+
+    @Accessor("useAnisotropicFiltering")
+    boolean navigator$usesAnisotropicFiltering();
+}


### PR DESCRIPTION
## Summary
Follow up on #20 
Was getting ready to PR so I migrated my test modpack instance to daily 646 that had the other PR release in it.

And I was greeted with this:
<img width="965" height="623" alt="image" src="https://github.com/user-attachments/assets/181811eb-fabc-48f3-b765-ceaaa6623758" />

Long story short, this is caused by https://github.com/GTNewHorizons/Angelica/pull/1952
But this also probably would happen for anyone enabling filtering, was a missed thing on my part.

This fix the issue, tested both with and without angelica. It will properly adapt to the current filtering setting.


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
